### PR TITLE
Refactor CurationConcerns event hooks and messaging services. Fixes #6

### DIFF
--- a/app/services/sufia/audit_failure_service.rb
+++ b/app/services/sufia/audit_failure_service.rb
@@ -1,0 +1,20 @@
+module Sufia
+  class AuditFailureService < MessageUserService
+    attr_reader :log_date
+
+    def initialize(generic_file, user, log_date)
+      @log_date = log_date
+      super(generic_file, user)
+    end
+
+    def message
+      uri = generic_file.original_file.uri.to_s
+      file_title = generic_file.title.first
+      "The audit run at #{log_date} for #{file_title} (#{uri}) failed."
+    end
+
+    def subject
+      'Failing Audit Run'
+    end
+  end
+end

--- a/app/services/sufia/import_local_file_failure_service.rb
+++ b/app/services/sufia/import_local_file_failure_service.rb
@@ -1,0 +1,18 @@
+module Sufia
+  class ImportLocalFileFailureService < MessageUserService
+    attr_reader :filename
+
+    def initialize(generic_file, user, filename)
+      @filename = filename
+      super(generic_file, user)
+    end
+
+    def message
+      "There was a problem depositing #{File.basename(filename)}. Please contact a system admin."
+    end
+
+    def subject
+      'Local file ingest error'
+    end
+  end
+end

--- a/app/services/sufia/import_local_file_success_service.rb
+++ b/app/services/sufia/import_local_file_success_service.rb
@@ -1,0 +1,23 @@
+module Sufia
+  class ImportLocalFileSuccessService < MessageUserService
+    attr_reader :filename
+
+    def initialize(generic_file, user, filename)
+      @filename = filename
+      super(generic_file, user)
+    end
+
+    def call
+      CurationConcerns.queue.push(ContentDepositEventJob.new(generic_file.id, user.user_key))
+      super
+    end
+
+    def message
+      "The file (#{File.basename(filename)}) was successfully deposited."
+    end
+
+    def subject
+      'Local file ingest'
+    end
+  end
+end

--- a/app/services/sufia/import_url_failure_service.rb
+++ b/app/services/sufia/import_url_failure_service.rb
@@ -1,0 +1,11 @@
+module Sufia
+  class ImportUrlFailureService < MessageUserService
+    def message
+      generic_file.errors.full_messages.join(', ')
+    end
+
+    def subject
+      'File Import Error'
+    end
+  end
+end

--- a/app/services/sufia/import_url_success_service.rb
+++ b/app/services/sufia/import_url_success_service.rb
@@ -1,0 +1,16 @@
+module Sufia
+  class ImportUrlSuccessService < MessageUserService
+    def call
+      CurationConcerns.queue.push(ContentDepositEventJob.new(generic_file.id, user.user_key))
+      super
+    end
+
+    def message
+      "The file (#{generic_file.label}) was successfully imported."
+    end
+
+    def subject
+      'File Import'
+    end
+  end
+end

--- a/app/services/sufia/message_user_service.rb
+++ b/app/services/sufia/message_user_service.rb
@@ -1,0 +1,30 @@
+module Sufia
+  class MessageUserService
+    attr_reader :generic_file, :user
+
+    def initialize(generic_file, user)
+      @generic_file = generic_file
+      @user = user
+    end
+
+    def call
+      job_user.send_message(user, message, subject)
+    end
+
+    # Passed into send_message, override to provide message body for event.
+    def message
+      raise "Override #message in the service class"
+    end
+
+    # Passed into send_message, override to provide subject for event.
+    def subject
+      raise "Override #subject in the service class"
+    end
+
+    private
+
+      def job_user
+        ::User.audituser
+      end
+  end
+end

--- a/config/initializers/curation_concern_events.rb
+++ b/config/initializers/curation_concern_events.rb
@@ -18,3 +18,23 @@ CurationConcerns.config.after_update_metadata = lambda { |generic_file, user|
 CurationConcerns.config.after_destroy = lambda { |id, user|
   CurationConcerns.queue.push(ContentDeleteEventJob.new(id, user.user_key))
 }
+
+CurationConcerns.config.after_audit_failure = lambda { |generic_file, user, log_date|
+  Sufia::AuditFailureService.new(generic_file, user, log_date).call
+}
+
+CurationConcerns.config.after_import_url_success = lambda { |generic_file, user|
+  Sufia::ImportUrlSuccessService.new(generic_file, user).call
+}
+
+CurationConcerns.config.after_import_url_failure = lambda { |generic_file, user|
+  Sufia::ImportUrlFailureService.new(generic_file, user).call
+}
+
+CurationConcerns.config.after_import_local_file_success = lambda { |generic_file, user, filename|
+  Sufia::ImportLocalFileSuccessService.new(generic_file, user, filename).call
+}
+
+CurationConcerns.config.after_import_local_file_failure = lambda { |generic_file, user, filename|
+  Sufia::ImportLocalFileFailureService.new(generic_file, user, filename).call
+}

--- a/spec/services/sufia/audit_failure_service_spec.rb
+++ b/spec/services/sufia/audit_failure_service_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe Sufia::AuditFailureService do
+  let!(:depositor){ FactoryGirl.find_or_create(:jill) }
+  let!(:log_date) { '2015-07-15 03:06:59' }
+  let(:inbox) { depositor.mailbox.inbox }
+  let(:file) do
+    GenericFile.create do |file|
+      file.apply_depositor_metadata(depositor)
+    end
+  end
+
+  before do
+    allow(file).to receive(:log_date).and_return('2015-07-15 03:06:59')
+    allow(file).to receive(:title).and_return('World Icon')
+    allow(file.original_file).to receive(:uri).and_return("http://localhost:8983/fedora/rest/test/nv/93/5x/32/nv935x32f/files/e5b91275-aab7-4720-88d4-c153d7196c23")
+  end
+
+  describe "#call" do
+    subject { described_class.new(file, depositor, log_date) }
+
+    it "sends failing mail" do
+      subject.call
+      expect(inbox.count).to eq(1)
+      inbox.each { |msg| expect(msg.last_message.subject).to eq('Failing Audit Run') }
+    end
+  end
+end

--- a/spec/services/sufia/import_local_file_failure_service.rb
+++ b/spec/services/sufia/import_local_file_failure_service.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe Sufia::ImportLocalFileFailureService do
+  let!(:depositor){ FactoryGirl.find_or_create(:jill) }
+  let!(:filename) { 'world.png' }
+  let(:inbox) { depositor.mailbox.inbox }
+  let(:file) do
+    GenericFile.create do |file|
+      file.apply_depositor_metadata(depositor)
+    end
+  end
+
+  before do
+    allow(GenericFile).to receive(:find).and_return(file)
+    Sufia::ImportLocalFileFailureService.new(file.id, depositor.user_key, filename).call
+  end
+  describe "#call" do
+    it "sends failing mail" do
+      expect(inbox.count).to eq(1)
+      inbox.each { |msg| expect(msg.last_message.subject).to eq('Local file ingest error') }
+    end
+  end
+end

--- a/spec/services/sufia/import_local_file_success_service_spec.rb
+++ b/spec/services/sufia/import_local_file_success_service_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe Sufia::ImportLocalFileSuccessService do
+  let!(:depositor){ FactoryGirl.find_or_create(:jill) }
+  let!(:filename) { 'world.png' }
+  let(:inbox) { depositor.mailbox.inbox }
+  let(:file) do
+    GenericFile.create do |file|
+      file.apply_depositor_metadata(depositor)
+    end
+  end
+
+  describe '#call' do
+    subject { described_class.new(file, depositor, filename) }
+
+    it 'sends success mail' do
+      subject.call
+      expect(inbox.count).to eq(1)
+      expect(inbox.first.last_message.subject).to eq('Local file ingest')
+      expect(inbox.first.last_message.body).to eq("The file (#{filename}) was successfully deposited.")
+    end
+
+    it 'spawns a deposit event job' do
+      expect(ContentDepositEventJob).to receive(:new).with(file.id, depositor.user_key).once.and_call_original
+      subject.call
+    end
+  end
+end

--- a/spec/services/sufia/import_url_failure_service_spec.rb
+++ b/spec/services/sufia/import_url_failure_service_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe Sufia::ImportUrlFailureService do
+  let!(:depositor){ FactoryGirl.find_or_create(:jill) }
+  let(:inbox) { depositor.mailbox.inbox }
+  let(:file) do
+    GenericFile.create do |file|
+      file.apply_depositor_metadata(depositor)
+    end
+  end
+
+  before do
+    allow(file.errors).to receive(:full_messages).and_return(['huge mistake'])
+  end
+
+  describe "#call" do
+    before do
+      described_class.new(file, depositor).call
+    end
+
+    it "sends failing mail" do
+      expect(inbox.count).to eq(1)
+      expect(inbox.first.last_message.subject).to eq('File Import Error')
+    end
+  end
+end

--- a/spec/services/sufia/import_url_success_service_spec.rb
+++ b/spec/services/sufia/import_url_success_service_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe Sufia::ImportUrlSuccessService do
+  let!(:depositor){ FactoryGirl.find_or_create(:jill) }
+  let(:inbox) { depositor.mailbox.inbox }
+  let(:label) { 'foobarbaz' }
+  let(:file) do
+    GenericFile.create do |file|
+      file.apply_depositor_metadata(depositor)
+      file.label = label
+    end
+  end
+
+  describe "#call" do
+    before do
+      described_class.new(file, depositor).call
+    end
+
+    it "sends success mail" do
+      expect(inbox.count).to eq(1)
+      expect(inbox.first.last_message.subject).to eq('File Import')
+      expect(inbox.first.last_message.body).to eq("The file (#{label}) was successfully imported.")
+    end
+  end
+end


### PR DESCRIPTION
This PR adds handlers to Sufia::Core that trigger when CurationConcerns' event
hooks fire off. Rename the initializer that handles these hooks to reflect that
the events originate in CurationConcerns rather than Sufia. Disentangle event
jobs -- which should only populate Redis-based activity streams -- from user
messaging functions. Handle event hooks in service objects, which message the
user (using Mailboxer, backed by the application database) and spawn event
jobs as appropriate. These services may be extended by downstream adopters.