### PR TITLE
Get the GenericFilesController specs passing. Refs #10

### DIFF
--- a/app/controllers/concerns/sufia/files_controller/browse_everything.rb
+++ b/app/controllers/concerns/sufia/files_controller/browse_everything.rb
@@ -2,7 +2,7 @@ module Sufia::FilesController
   module BrowseEverything
     include ActiveSupport::Concern
 
-    def create 
+    def create
       if params[:selected_files].present?
         create_from_browse_everything(params)
       else
@@ -13,20 +13,20 @@ module Sufia::FilesController
     protected
 
       def create_from_browse_everything(params)
-        Batch.find_or_create(params[:batch_id])        
-        params[:selected_files].each_pair do |index, file_info| 
+        Batch.find_or_create(params[:batch_id])
+        params[:selected_files].each_pair do |index, file_info|
           next if file_info.blank? || file_info["url"].blank?
           create_file_from_url(file_info["url"], file_info["file_name"])
         end
         redirect_to self.class.upload_complete_path( params[:batch_id])
       end
-      
+
       # Generic utility for creating GenericFile from a URL
-      # Used in to import files using URLs from a file picker like browse_everything 
+      # Used in to import files using URLs from a file picker like browse_everything
       def create_file_from_url(url, file_name)
         generic_file = ::GenericFile.new(import_url: url, label: file_name).tap do |gf|
           actor = CurationConcerns::GenericFileActor.new(gf, current_user)
-          actor.create_metadata(params[:batch_id], params[:work_id])
+          actor.create_metadata(params[:batch_id], params[:parent_id])
           gf.save!
           CurationConcerns.queue.push(ImportUrlJob.new(gf.id))
         end

--- a/app/controllers/concerns/sufia/files_controller/local_ingest_behavior.rb
+++ b/app/controllers/concerns/sufia/files_controller/local_ingest_behavior.rb
@@ -57,7 +57,7 @@ module Sufia
       generic_file = ::GenericFile.new(label: basename).tap do |gf|
         gf.relative_path = filename if filename != basename
         actor = CurationConcerns::GenericFileActor.new(gf, current_user)
-        actor.create_metadata(params[:batch_id], params[:work_id])
+        actor.create_metadata(params[:batch_id], params[:parent_id])
         gf.save!
         CurationConcerns.queue.push(IngestLocalFileJob.new(gf.id, current_user.directory, filename, current_user.user_key))
       end

--- a/app/controllers/concerns/sufia/users_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/users_controller_behavior.rb
@@ -70,17 +70,17 @@ module Sufia::UsersControllerBehavior
   end
 
   def toggle_trophy
-     unless current_user.can? :edit, params[:work_id]
+     unless current_user.can? :edit, params[:parent_id]
        redirect_to root_path, alert: "You do not have permissions to the work"
        return false
      end
-     t = current_user.trophies.where(generic_work_id: params[:work_id]).first
+     t = current_user.trophies.where(generic_work_id: params[:parent_id]).first
      if t
        t.destroy
        #TODO do this better says Mike
        return false if t.persisted?
      else
-       t = current_user.trophies.create(generic_work_id: params[:work_id])
+       t = current_user.trophies.create(generic_work_id: params[:parent_id])
        return false unless t.persisted?
      end
      render json: t

--- a/app/controllers/generic_files_controller.rb
+++ b/app/controllers/generic_files_controller.rb
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 class GenericFilesController < ApplicationController
+  include CurationConcerns::GenericFilesControllerBehavior
   include Sufia::Controller
   include Sufia::FilesControllerBehavior
 end

--- a/app/views/generic_files/upload/_form_fields.html.erb
+++ b/app/views/generic_files/upload/_form_fields.html.erb
@@ -2,7 +2,7 @@
       <%= hidden_field_tag(:total_upload_size, 0) %>
       <%= hidden_field_tag(:relative_path) %>
       <%= hidden_field_tag(:batch_id, @batch_id) %>
-      <%= hidden_field_tag(:work_id, @work_id) %>
+      <%= hidden_field_tag(:parent_id, @work_id) %>
       <%= hidden_field_tag "file_coming_from", "local" %>
       <%= render partial: 'generic_files/upload/tos_checkbox' %>
         <!-- The fileupload-buttonbar contains buttons to add/delete files and start/cancel the upload -->

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -298,22 +298,22 @@ describe UsersController, :type => :controller do
 
   describe "#toggle_trophy" do
      let(:work) { GenericWork.create { |w| w.apply_depositor_metadata(user) } }
-     let(:work_id) { work.id }
+     let(:parent_id) { work.id }
      let(:another_user) { FactoryGirl.create(:user) }
 
      it "should trophy a work" do
-      post :toggle_trophy, {id: user.user_key, work_id: work_id}
+      post :toggle_trophy, {id: user.user_key, parent_id: parent_id}
       json = JSON.parse(response.body)
       expect(json['user_id']).to eq user.id
-      expect(json['generic_work_id']).to eq work_id
+      expect(json['generic_work_id']).to eq parent_id
     end
      it "should not trophy a work for a different user" do
-      post :toggle_trophy, {id: another_user.user_key, work_id: work_id}
+      post :toggle_trophy, {id: another_user.user_key, parent_id: parent_id}
       expect(response).to_not be_success
     end
      it "should not trophy a work with no edit privs" do
       sign_in another_user
-      post :toggle_trophy, {id: another_user.user_key, work_id: work_id}
+      post :toggle_trophy, {id: another_user.user_key, parent_id: parent_id}
       expect(response).to_not be_success
     end
   end

--- a/sufia-models/lib/sufia/models/virus_found_error.rb
+++ b/sufia-models/lib/sufia/models/virus_found_error.rb
@@ -1,4 +1,0 @@
-module Sufia
-  class VirusFoundError < StandardError
-  end
-end


### PR DESCRIPTION
This is a work in progress, with three failing specs.  Created a PR because @jcoyne asked for it.

* include CurationConcerns::FilesController into GenericFilesController
* use parent_id instead of work_id
* rely on CurationConcerns::FilesController.create
* handle cases where @generic_file.original_file is nil
* pass correct arguments into actor.create_metadata