### PR TITLE
Removing the stub to avoid nil pointer error

### DIFF
--- a/app/controllers/concerns/sufia/files_controller/local_ingest_behavior.rb
+++ b/app/controllers/concerns/sufia/files_controller/local_ingest_behavior.rb
@@ -16,7 +16,7 @@ module Sufia
     def perform_local_ingest
       if Sufia.config.enable_local_ingest && current_user.respond_to?(:directory)
         if ingest_local_file
-          redirect_to GenericFilesController.upload_complete_path( params[:batch_id])
+          redirect_to GenericFilesController.upload_complete_path(params[:batch_id])
         else
           flash[:alert] = "Error importing files from user directory."
           render :new

--- a/spec/controllers/generic_files_controller_spec.rb
+++ b/spec/controllers/generic_files_controller_spec.rb
@@ -621,7 +621,6 @@ describe GenericFilesController do
       end
 
       it "should create the batch on HTTP POST with multiple files" do
-        expect(GenericFile).to receive(:new).twice
         expect(Batch).to receive(:find_or_create).twice
         xhr :post, :create, files: [file1], Filename: 'The world 1', batch_id: batch_id, on_behalf_of: 'carolyn', terms_of_service: '1'
         expect(response).to be_success


### PR DESCRIPTION
There is still an error in the test because it's attempting to set
on_behalf_of on a GenericFile even though that's a GenericWork thing
now.