### PR TITLE
Minimal changes to allow rspec to run

### DIFF
--- a/app/controllers/concerns/sufia/batch_edits_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/batch_edits_controller_behavior.rb
@@ -76,12 +76,12 @@ module Sufia
       end
 
       def terms
-        Forms::UploadSetEditForm.terms
+        Forms::BatchEditForm.terms
       end
 
       def file_set_params
         file_params = params[:file_set] || ActionController::Parameters.new
-        Forms::UploadSetEditForm.model_attributes(file_params)
+        Forms::BatchEditForm.model_attributes(file_params)
       end
 
       def redirect_to_return_controller

--- a/app/controllers/concerns/sufia/upload_sets_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/upload_sets_controller_behavior.rb
@@ -8,7 +8,7 @@ module Sufia
 
       before_action :has_access?
       class_attribute :edit_form_class
-      self.edit_form_class = Sufia::Forms::UploadSetEditForm
+      self.edit_form_class = CurationConcerns::Forms::FileSetEditForm
     end
 
     def edit

--- a/app/models/concerns/sufia/solr_document_behavior.rb
+++ b/app/models/concerns/sufia/solr_document_behavior.rb
@@ -2,7 +2,7 @@
 module Sufia
   module SolrDocumentBehavior
     extend ActiveSupport::Concern
-    include Hydra::Works::FileSet::MimeTypes
+    include Hydra::Works::MimeTypes
     include Sufia::Permissions::Readable
 
     # Add a schema.org itemtype

--- a/spec/controllers/file_sets_controller_spec.rb
+++ b/spec/controllers/file_sets_controller_spec.rb
@@ -621,13 +621,13 @@ describe FileSetsController do
       let(:file2) { fixture_file_upload('/image.jpg', 'image/png') }
 
       it "does not create the batch on HTTP GET" do
-        expect(UploadSet..not_to receive(:create)
+        expect(UploadSet).not_to receive(:create)
         xhr :get, :new
         expect(response).to be_success
       end
 
       it "creates the batch on HTTP POST with multiple files" do
-        expect(UploadSet..to receive(:find_or_create).twice
+        expect(UploadSet).to receive(:find_or_create).twice
         xhr :post, :create, files: [file1], Filename: 'The world 1', upload_set_id: upload_set_id, on_behalf_of: 'carolyn', terms_of_service: '1'
         expect(response).to be_success
         xhr :post, :create, files: [file2], Filename: 'An image', upload_set_id: upload_set_id, on_behalf_of: 'carolyn', terms_of_service: '1'

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -24,7 +24,7 @@ describe SolrDocument, type: :model do
 
   describe "document types" do
     class Mimes
-      include Hydra::Works::FileSet::MimeTypes
+      include Hydra::Works::MimeTypes
     end
 
     context "when mime-type is 'office'" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,0 +1,2 @@
+# This file is normaly copied to spec/ when you run 'rails generate rspec:install'
+# but this is a dummy file to allow sufia specs to run.

--- a/spec/routing/route_spec.rb
+++ b/spec/routing/route_spec.rb
@@ -57,7 +57,7 @@ describe 'Routes', type: :routing do
     end
   end
 
-  describe 'UploadSet do
+  describe 'UploadSet' do
     it "routes to edit" do
       expect(get: '/upload_sets/1/edit').to route_to(controller: 'upload_set', action: 'edit', id: '1')
     end

--- a/spec/views/batch/edit.html.erb_spec.rb
+++ b/spec/views/batch/edit.html.erb_spec.rb
@@ -7,7 +7,7 @@ describe 'batch/edit.html.erb' do
       f.apply_depositor_metadata("bob")
     end
   end
-  let(:form) { Sufia::Forms::UploadSetEditForm.new(file_set) }
+  let(:form) { CurationConcerns::Forms::FileSetEditForm.new(file_set) }
 
   before do
     allow(controller).to receive(:current_user).and_return(stub_model(User))

--- a/sufia-models/lib/generators/sufia/models/templates/migrations/change_audit_log_pid_to_generic_file_id.rb
+++ b/sufia-models/lib/generators/sufia/models/templates/migrations/change_audit_log_pid_to_generic_file_id.rb
@@ -1,5 +1,5 @@
 class ChangeAuditLogPidToGenericFileId < ActiveRecord::Migration
   def change
-    rename_column :checksum_audit_logs, :pid, :generic_file_id unless ChecksumAuditLog.column_names.include?('generic_file_id')
+    rename_column :checksum_audit_logs, :pid, :generic_file_id if ChecksumAuditLog.column_names.include?('pid')
   end
 end

--- a/sufia-models/lib/generators/sufia/models/templates/migrations/change_proxy_deposit_request_generic_file_id_to_generic_work_id.rb
+++ b/sufia-models/lib/generators/sufia/models/templates/migrations/change_proxy_deposit_request_generic_file_id_to_generic_work_id.rb
@@ -1,5 +1,5 @@
 class ChangeProxyDepositRequestGenericFileIdToGenericWorkId < ActiveRecord::Migration
   def change
-    rename_column :proxy_deposit_requests, :generic_file_id, :generic_work_id
+    rename_column :proxy_deposit_requests, :generic_file_id, :generic_work_id if ProxyDepositRequest.column_names.include?('generic_file_id')
   end
 end

--- a/sufia-models/lib/generators/sufia/models/upgrade600_generator.rb
+++ b/sufia-models/lib/generators/sufia/models/upgrade600_generator.rb
@@ -11,6 +11,7 @@ This generator for upgrading sufia-models to 6.0 makes the following changes to 
   # Setup the database migrations
   def copy_migrations
     [
+      # Related to issue#97.  Migration is fails for install.
       'change_audit_log_pid_to_generic_file_id.rb',
       'change_proxy_deposit_request_pid_to_generic_file_id.rb'
     ].each do |file|


### PR DESCRIPTION
Add dummy rails_helper to allow rspec to run.
Refactor MimeType namespace to match current HydraWorks.
Comment out upgrade specific migrations. Issue#97.