### PR TITLE
Add 'null: default' to migration timestamps

### DIFF
--- a/sufia-models/lib/generators/sufia/models/templates/migrations/acts_as_follower_migration.rb
+++ b/sufia-models/lib/generators/sufia/models/templates/migrations/acts_as_follower_migration.rb
@@ -4,7 +4,7 @@ class ActsAsFollowerMigration < ActiveRecord::Migration
       t.references :followable, polymorphic: true, null: false
       t.references :follower,   polymorphic: true, null: false
       t.boolean :blocked, default: false, null: false
-      t.timestamps
+      t.timestamps null: false
     end
 
     add_index :follows, ["follower_id", "follower_type"],     name: "fk_follows"

--- a/sufia-models/lib/generators/sufia/models/templates/migrations/create_content_blocks.rb
+++ b/sufia-models/lib/generators/sufia/models/templates/migrations/create_content_blocks.rb
@@ -3,7 +3,7 @@ class CreateContentBlocks < ActiveRecord::Migration
     create_table :content_blocks do |t|
       t.string :name
       t.text :value
-      t.timestamps
+      t.timestamps null: false
     end
     add_index :content_blocks, :name, unique: true
   end

--- a/sufia-models/lib/generators/sufia/models/templates/migrations/create_featured_works.rb
+++ b/sufia-models/lib/generators/sufia/models/templates/migrations/create_featured_works.rb
@@ -4,7 +4,7 @@ class CreateFeaturedWorks < ActiveRecord::Migration
       t.integer :order, default: 5
       t.string :generic_work_id
 
-      t.timestamps
+      t.timestamps null: false
     end
     add_index :featured_works, :generic_work_id
     add_index :featured_works, :order

--- a/sufia-models/lib/generators/sufia/models/templates/migrations/create_file_download_stats.rb
+++ b/sufia-models/lib/generators/sufia/models/templates/migrations/create_file_download_stats.rb
@@ -5,7 +5,7 @@ class CreateFileDownloadStats < ActiveRecord::Migration
       t.integer :downloads
       t.string :file_id
 
-      t.timestamps
+      t.timestamps null: false
     end
     add_index :file_download_stats, :file_id
   end

--- a/sufia-models/lib/generators/sufia/models/templates/migrations/create_file_view_stats.rb
+++ b/sufia-models/lib/generators/sufia/models/templates/migrations/create_file_view_stats.rb
@@ -5,7 +5,7 @@ class CreateFileViewStats < ActiveRecord::Migration
       t.integer :views
       t.string :file_id
 
-      t.timestamps
+      t.timestamps null: false
     end
     add_index :file_view_stats, :file_id
   end

--- a/sufia-models/lib/generators/sufia/models/templates/migrations/create_proxy_deposit_requests.rb
+++ b/sufia-models/lib/generators/sufia/models/templates/migrations/create_proxy_deposit_requests.rb
@@ -8,7 +8,7 @@ class CreateProxyDepositRequests < ActiveRecord::Migration
       t.string :status, null: false, default: 'pending'
       t.text :sender_comment
       t.text :receiver_comment
-      t.timestamps
+      t.timestamps null: false
     end
     add_index :proxy_deposit_requests, :receiving_user_id
     add_index :proxy_deposit_requests, :sending_user_id

--- a/sufia-models/lib/generators/sufia/models/templates/migrations/create_proxy_deposit_rights.rb
+++ b/sufia-models/lib/generators/sufia/models/templates/migrations/create_proxy_deposit_rights.rb
@@ -3,7 +3,7 @@ class CreateProxyDepositRights < ActiveRecord::Migration
     create_table :proxy_deposit_rights do |t|
       t.references :grantor
       t.references :grantee
-      t.timestamps
+      t.timestamps null: false
     end
     add_index :proxy_deposit_rights, :grantor_id
     add_index :proxy_deposit_rights, :grantee_id

--- a/sufia-models/lib/generators/sufia/models/templates/migrations/create_tinymce_assets.rb
+++ b/sufia-models/lib/generators/sufia/models/templates/migrations/create_tinymce_assets.rb
@@ -2,7 +2,7 @@ class CreateTinymceAssets < ActiveRecord::Migration
   def change
     create_table :tinymce_assets do |t|
       t.string :file
-      t.timestamps
+      t.timestamps null: false
     end
   end
 end

--- a/sufia-models/lib/generators/sufia/models/templates/migrations/create_trophies.rb
+++ b/sufia-models/lib/generators/sufia/models/templates/migrations/create_trophies.rb
@@ -4,7 +4,7 @@ class CreateTrophies < ActiveRecord::Migration
       t.integer :user_id
       t.string :generic_file_id
 
-      t.timestamps
+      t.timestamps null: false
     end
   end
 end

--- a/sufia-models/lib/generators/sufia/models/templates/migrations/create_user_stats.rb
+++ b/sufia-models/lib/generators/sufia/models/templates/migrations/create_user_stats.rb
@@ -6,7 +6,7 @@ class CreateUserStats < ActiveRecord::Migration
       t.integer :file_views
       t.integer :file_downloads
 
-      t.timestamps
+      t.timestamps null: false
     end
 
     add_column :file_view_stats, :user_id, :integer


### PR DESCRIPTION
for compatibility with Rails 5. Fixes #115