### PR TITLE
Refactor to use ActiveJob for queueing jobs.

### DIFF
--- a/app/controllers/concerns/sufia/files_controller/browse_everything.rb
+++ b/app/controllers/concerns/sufia/files_controller/browse_everything.rb
@@ -28,7 +28,7 @@ module Sufia::FilesController
           actor = CurationConcerns::FileSetActor.new(fs, current_user)
           actor.create_metadata(params[:upload_set_id], params[:parent_id])
           fs.save!
-          CurationConcerns.queue.push(ImportUrlJob.new(fs.id))
+          ImportUrlJob.perform_later(fs.id)
         end
       end
   end

--- a/app/controllers/concerns/sufia/files_controller/local_ingest_behavior.rb
+++ b/app/controllers/concerns/sufia/files_controller/local_ingest_behavior.rb
@@ -58,7 +58,7 @@ module Sufia
           actor = CurationConcerns::FileSetActor.new(fs, current_user)
           actor.create_metadata(params[:upload_set_id], params[:parent_id])
           fs.save!
-          CurationConcerns.queue.push(IngestLocalFileJob.new(fs.id, current_user.directory, filename, current_user.user_key))
+          IngestLocalFileJob.perform_later(fs.id, current_user.directory, filename, current_user.user_key)
         end
       end
   end # /FilesController::LocalIngestBehavior

--- a/app/controllers/concerns/sufia/upload_sets_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/upload_sets_controller_behavior.rb
@@ -12,19 +12,19 @@ module Sufia
     end
 
     def edit
-      @batch = UploadSet.find_or_create(params[:id])
+      @upload_set = UploadSet.find_or_create(params[:id])
       @form = edit_form
     end
 
     def update
       authenticate_user!
-      @batch = UploadSet.find_or_create(params[:id])
-      @batch.status = ["processing"]
-      @batch.save
+      @upload_set = UploadSet.find_or_create(params[:id])
+      @upload_set.status = ["processing"]
+      @upload_set.save
       file_attributes = edit_form_class.model_attributes(params[:file_set])
-      CurationConcerns.queue.push(UploadSetUpdateJob.new(current_user.user_key, params[:id], params[:title], file_attributes, params[:visibility]))
+      UploadSetUpdateJob.perform_later(current_user.user_key, params[:id], params[:title], file_attributes, params[:visibility])
       flash[:notice] = 'Your files are being processed by ' + t('sufia.product_name') + ' in the background. The metadata and access controls you specified are being applied. Files will be marked <span class="label label-danger" title="Private">Private</span> until this process is complete (shouldn\'t take too long, hang in there!). You may need to refresh your dashboard to see these updates.'
-      if uploading_on_behalf_of? @batch
+      if uploading_on_behalf_of? @upload_set
         redirect_to sufia.dashboard_shares_path
       else
         redirect_to sufia.dashboard_files_path
@@ -34,14 +34,14 @@ module Sufia
     protected
 
       def edit_form
-        file_set = ::FileSet.new(creator: [current_user.name], title: @batch.file_sets.map(&:label))
+        file_set = ::FileSet.new(creator: [current_user.name], title: @upload_set.file_sets.map(&:label))
         edit_form_class.new(file_set)
       end
 
-      def uploading_on_behalf_of?(batch)
-        return false if batch.file_sets.empty?
+      def uploading_on_behalf_of?(upload_set)
+        return false if upload_set.file_sets.empty?
 
-        work = batch.file_sets.first.generic_works.first
+        work = upload_set.file_sets.first.generic_works.first
         return false if work.nil? || work.on_behalf_of.blank?
         current_user.user_key != work.on_behalf_of
       end

--- a/app/controllers/concerns/sufia/users_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/users_controller_behavior.rb
@@ -59,7 +59,7 @@ module Sufia::UsersControllerBehavior
       smash_trophy = smash_trophy.sub(/^remove_trophy_/, '')
       current_user.trophies.where(generic_work_id: smash_trophy).destroy_all
     end
-    CurationConcerns.queue.push(UserEditProfileEventJob.new(@user.user_key))
+    UserEditProfileEventJob.perform_later(@user.user_key)
     redirect_to sufia.profile_path(@user.to_param), notice: "Your profile has been updated"
   end
 
@@ -88,7 +88,7 @@ module Sufia::UsersControllerBehavior
   def follow
     unless current_user.following?(@user)
       current_user.follow(@user)
-      CurationConcerns.queue.push(UserFollowEventJob.new(current_user.user_key, @user.user_key))
+      UserFollowEventJob.perform_later(current_user.user_key, @user.user_key)
     end
     redirect_to sufia.profile_path(@user.to_param), notice: "You are following #{@user}"
   end
@@ -97,7 +97,7 @@ module Sufia::UsersControllerBehavior
   def unfollow
     if current_user.following?(@user)
       current_user.stop_following(@user)
-      CurationConcerns.queue.push(UserUnfollowEventJob.new(current_user.user_key, @user.user_key))
+      UserUnfollowEventJob.perform_later(current_user.user_key, @user.user_key)
     end
     redirect_to sufia.profile_path(@user.to_param), notice: "You are no longer following #{@user}"
   end

--- a/app/jobs/content_delete_event_job.rb
+++ b/app/jobs/content_delete_event_job.rb
@@ -1,5 +1,5 @@
 class ContentDeleteEventJob < EventJob
-  def run
+  def perform(id, depositor_id)
     action = "User #{link_to_profile depositor_id} has deleted file '#{id}'"
     timestamp = Time.now.to_i
     depositor = User.find_by_user_key(depositor_id)

--- a/app/jobs/content_deposit_event_job.rb
+++ b/app/jobs/content_deposit_event_job.rb
@@ -1,5 +1,5 @@
 class ContentDepositEventJob < EventJob
-  def run
+  def perform(id, depositor_id)
     fs = FileSet.find(id)
     action = "User #{link_to_profile depositor_id} has deposited #{link_to fs.title.first, Sufia::Engine.routes.url_helpers.file_set_path(fs)}"
     timestamp = Time.now.to_i

--- a/app/jobs/content_depositor_change_event_job.rb
+++ b/app/jobs/content_depositor_change_event_job.rb
@@ -1,20 +1,10 @@
 class ContentDepositorChangeEventJob < EventJob
-  def queue_name
-    :proxy_deposit
-  end
-
-  attr_accessor :id, :login, :reset
+  queue_as :proxy_deposit
 
   # @param [String] id identifier of the generic work to be transfered
   # @param [String] login the user key of the user the generic work is being transfered to.
   # @param [Boolean] reset (false) should the access controls be reset. This means revoking edit access from the depositor
-  def initialize(id, login, reset = false)
-    self.id = id
-    self.login = login
-    self.reset = reset
-  end
-
-  def run
+  def perform(id, login, reset = false)
     # TODO: This should be in its own job, not this event job
     work = ::GenericWork.find(id)
     work.proxy_depositor = work.depositor

--- a/app/jobs/content_new_version_event_job.rb
+++ b/app/jobs/content_new_version_event_job.rb
@@ -1,5 +1,5 @@
 class ContentNewVersionEventJob < EventJob
-  def run
+  def perform(id, depositor_id)
     fs = FileSet.find(id)
     action = "User #{link_to_profile depositor_id} has added a new version of #{link_to fs.title.first, Sufia::Engine.routes.url_helpers.file_set_path(fs)}"
     timestamp = Time.now.to_i

--- a/app/jobs/content_restored_version_event_job.rb
+++ b/app/jobs/content_restored_version_event_job.rb
@@ -1,13 +1,5 @@
 class ContentRestoredVersionEventJob < EventJob
-  attr_accessor :revision_id
-
-  def initialize(file_set_id, depositor_id, revision_id)
-    self.id = file_set_id
-    self.depositor_id = depositor_id
-    self.revision_id = revision_id
-  end
-
-  def run
+  def perform(id, depositor_id, revision_id)
     fs = FileSet.find(id)
     action = "User #{link_to_profile depositor_id} has restored a version '#{revision_id}' of #{link_to fs.title.first, Sufia::Engine.routes.url_helpers.file_set_path(fs)}"
     timestamp = Time.now.to_i

--- a/app/jobs/content_update_event_job.rb
+++ b/app/jobs/content_update_event_job.rb
@@ -1,5 +1,5 @@
 class ContentUpdateEventJob < EventJob
-  def run
+  def perform(id, depositor_id)
     fs = FileSet.find(id)
     action = "User #{link_to_profile depositor_id} has updated #{link_to fs.title.first, Sufia::Engine.routes.url_helpers.file_set_path(fs)}"
     timestamp = Time.now.to_i

--- a/app/jobs/event_job.rb
+++ b/app/jobs/event_job.rb
@@ -1,18 +1,9 @@
-class EventJob
+class EventJob < ActiveJob::Base
   include Rails.application.routes.url_helpers
   include ActionView::Helpers
   include ActionView::Helpers::DateHelper
   include Hydra::AccessControlsEnforcement
   include SufiaHelper
 
-  def queue_name
-    :event
-  end
-
-  attr_accessor :id, :depositor_id
-
-  def initialize(id, depositor_id)
-    self.id = id
-    self.depositor_id = depositor_id
-  end
+  queue_as :event
 end

--- a/app/jobs/user_edit_profile_event_job.rb
+++ b/app/jobs/user_edit_profile_event_job.rb
@@ -1,11 +1,5 @@
 class UserEditProfileEventJob < EventJob
-  attr_accessor :editor_id
-
-  def initialize(editor_id)
-    self.editor_id = editor_id
-  end
-
-  def run
+  def perform(editor_id)
     action = "User #{link_to_profile editor_id} has edited his or her profile"
     timestamp = Time.now.to_i
     editor = User.find_by_user_key(editor_id)

--- a/app/jobs/user_follow_event_job.rb
+++ b/app/jobs/user_follow_event_job.rb
@@ -1,12 +1,5 @@
 class UserFollowEventJob < EventJob
-  attr_accessor :follower_id, :followee_id
-
-  def initialize(follower_id, followee_id)
-    self.follower_id = follower_id
-    self.followee_id = followee_id
-  end
-
-  def run
+  def perform(follower_id, followee_id)
     # Create the event
     follower = User.find_by_user_key(follower_id)
     event = follower.create_event("User #{link_to_profile follower_id} is now following #{link_to_profile followee_id}", Time.now.to_i)

--- a/app/jobs/user_unfollow_event_job.rb
+++ b/app/jobs/user_unfollow_event_job.rb
@@ -1,12 +1,5 @@
 class UserUnfollowEventJob < EventJob
-  attr_accessor :unfollower_id, :unfollowee_id
-
-  def initialize(unfollower_id, unfollowee_id)
-    self.unfollower_id = unfollower_id
-    self.unfollowee_id = unfollowee_id
-  end
-
-  def run
+  def perform(unfollower_id, unfollowee_id)
     action = "User #{link_to_profile unfollower_id} has unfollowed #{link_to_profile unfollowee_id}"
     timestamp = Time.now.to_i
     unfollower = User.find_by_user_key(unfollower_id)

--- a/app/services/sufia/import_local_file_success_service.rb
+++ b/app/services/sufia/import_local_file_success_service.rb
@@ -8,7 +8,7 @@ module Sufia
     end
 
     def call
-      CurationConcerns.queue.push(ContentDepositEventJob.new(file_set.id, user.user_key))
+      ContentDepositEventJob.perform_later(file_set.id, user.user_key)
       super
     end
 

--- a/app/services/sufia/import_url_success_service.rb
+++ b/app/services/sufia/import_url_success_service.rb
@@ -1,7 +1,7 @@
 module Sufia
   class ImportUrlSuccessService < MessageUserService
     def call
-      CurationConcerns.queue.push(ContentDepositEventJob.new(file_set.id, user.user_key))
+      ContentDepositEventJob.perform_later(file_set.id, user.user_key)
       super
     end
 

--- a/config/initializers/curation_concern_events.rb
+++ b/config/initializers/curation_concern_events.rb
@@ -1,22 +1,22 @@
 # These events are triggered by actions within CurationConcerns Actors
 CurationConcerns.config.callback.set(:after_create_content) do |file_set, user|
-  CurationConcerns.queue.push(ContentDepositEventJob.new(file_set.id, user.user_key))
+  ContentDepositEventJob.perform_later(file_set.id, user.user_key)
 end
 
 CurationConcerns.config.callback.set(:after_revert_content) do |file_set, user, revision|
-  CurationConcerns.queue.push(ContentRestoredVersionEventJob.new(file_set.id, user.user_key, revision))
+  ContentRestoredVersionEventJob.perform_later(file_set.id, user.user_key, revision)
 end
 
 CurationConcerns.config.callback.set(:after_update_content) do |file_set, user|
-  CurationConcerns.queue.push(ContentNewVersionEventJob.new(file_set.id, user.user_key))
+  ContentNewVersionEventJob.perform_later(file_set.id, user.user_key)
 end
 
 CurationConcerns.config.callback.set(:after_update_metadata) do |file_set, user|
-  CurationConcerns.queue.push(ContentUpdateEventJob.new(file_set.id, user.user_key))
+  ContentUpdateEventJob.perform_later(file_set.id, user.user_key)
 end
 
 CurationConcerns.config.callback.set(:after_destroy) do |id, user|
-  CurationConcerns.queue.push(ContentDeleteEventJob.new(id, user.user_key))
+  ContentDeleteEventJob.perform_later(id, user.user_key)
 end
 
 CurationConcerns.config.callback.set(:after_audit_failure) do |file_set, user, log_date|

--- a/spec/config/sufia_events_spec.rb
+++ b/spec/config/sufia_events_spec.rb
@@ -1,48 +1,44 @@
 require 'spec_helper'
 # Testing that these behaviors are configured (mainly they are triggered by CurationConcerns actors)
 describe "sufia_events initialers sets CurationConcerns.config" do
-  let(:file_set) { double("FileSet", id: "6789") }
-  let(:user) { double("User", user_key: "an_id") }
+  # TODO: mock file_set so it doesn't have to be created
+  let(:file_set)  { create(:file_set) }
+  let(:user)      { create(:user) }
 
   describe "after_create_content" do
     it "to queue a ContentDepositEventJob" do
-      expect(ContentDepositEventJob).to receive(:new).with(file_set.id, user.user_key).and_return("the_job")
-      expect(CurationConcerns.queue).to receive(:push).with("the_job")
-      CurationConcerns.config.after_create_content.call(file_set, user)
+      expect(ContentDepositEventJob).to receive(:perform_later).with(file_set.id, user.user_key).once
+      CurationConcerns.config.callback.run(:after_create_content, file_set, user)
     end
   end
 
   describe "after_revert_content" do
     let(:revision) { "revision1" }
     it "to queue a ContentDepositEventJob" do
-      expect(ContentRestoredVersionEventJob).to receive(:new).with(file_set.id, user.user_key, revision).and_return("the_job")
-      expect(CurationConcerns.queue).to receive(:push).with("the_job")
-      CurationConcerns.config.after_revert_content.call(file_set, user, revision)
+      expect(ContentRestoredVersionEventJob).to receive(:perform_later).with(file_set.id, user.user_key, revision).once
+      CurationConcerns.config.callback.run(:after_revert_content, file_set, user, revision)
     end
   end
 
   describe "after_update_content" do
     it "to queue a ContentDepositEventJob" do
-      expect(ContentNewVersionEventJob).to receive(:new).with(file_set.id, user.user_key).and_return("the_job")
-      expect(CurationConcerns.queue).to receive(:push).with("the_job")
-      CurationConcerns.config.after_update_content.call(file_set, user)
+      expect(ContentNewVersionEventJob).to receive(:perform_later).with(file_set.id, user.user_key).once
+      CurationConcerns.config.callback.run(:after_update_content, file_set, user)
     end
   end
 
   describe "after_update_metadata" do
     it "to queue a ContentDepositEventJob" do
-      expect(ContentUpdateEventJob).to receive(:new).with(file_set.id, user.user_key).and_return("the_job")
-      expect(CurationConcerns.queue).to receive(:push).with("the_job")
-      CurationConcerns.config.after_update_metadata.call(file_set, user)
+      expect(ContentUpdateEventJob).to receive(:perform_later).with(file_set.id, user.user_key).once
+      CurationConcerns.config.callback.run(:after_update_metadata, file_set, user)
     end
   end
 
   describe "after_destroy" do
     let(:id) { file_set.id }
     it "to queue a ContentDepositEventJob" do
-      expect(ContentDeleteEventJob).to receive(:new).with(id, user.user_key).and_return("the_job")
-      expect(CurationConcerns.queue).to receive(:push).with("the_job")
-      CurationConcerns.config.after_destroy.call(id, user)
+      expect(ContentDeleteEventJob).to receive(:perform_later).with(id, user.user_key).once
+      CurationConcerns.config.callback.run(:after_destroy, id, user)
     end
   end
 end

--- a/spec/controllers/upload_sets_controller_spec.rb
+++ b/spec/controllers/upload_sets_controller_spec.rb
@@ -11,12 +11,8 @@ describe UploadSetsController do
     let(:batch_update_message) { double('batch update message') }
     let(:batch) { UploadSet.create }
     context "enquing a batch job" do
-      before do
-        allow(UploadSetUpdateJob).to receive(:new).with(user.user_key, batch.id, { '1' => 'foo' },
-                                                        { tag: [] }, 'open').and_return(batch_update_message)
-      end
       it "is successful" do
-        expect(CurationConcerns.queue).to receive(:push).with(batch_update_message).once
+        expect(UploadSetUpdateJob).to receive(:new).with(user.user_key, batch.id, { '1' => 'foo' }, { tag: [] }, 'open').once
         post :update, id: batch.id, title: { '1' => 'foo' }, visibility: 'open', file_set: { tag: [""] }
         expect(response).to redirect_to routes.url_helpers.dashboard_files_path
         expect(flash[:notice]).to include("Your files are being processed")

--- a/spec/jobs/event_jobs_spec.rb
+++ b/spec/jobs/event_jobs_spec.rb
@@ -27,7 +27,7 @@ describe 'event jobs' do
     count_another = @another_user.events.length
     expect(Time).to receive(:now).at_least(:once).and_return(1)
     event = { action: 'User <a href="/users/jilluser@example-dot-com">jilluser@example.com</a> has edited his or her profile', timestamp: '1' }
-    UserEditProfileEventJob.new(@user.user_key).run
+    UserEditProfileEventJob.perform_now(@user.user_key)
     expect(@user.events.length).to eq(count_user + 1)
     expect(@user.events.first).to eq(event)
     expect(@another_user.events.length).to eq(count_another + 1)
@@ -41,7 +41,7 @@ describe 'event jobs' do
     expect(@third_user.events.length).to eq(0)
     expect(Time).to receive(:now).at_least(:once).and_return(1)
     event = { action: 'User <a href="/users/jilluser@example-dot-com">jilluser@example.com</a> is now following <a href="/users/archivist1@example-dot-com">archivist1@example.com</a>', timestamp: '1' }
-    UserFollowEventJob.new(@user.user_key, @another_user.user_key).run
+    UserFollowEventJob.perform_now(@user.user_key, @another_user.user_key)
     expect(@user.events.length).to eq(1)
     expect(@user.events.first).to eq(event)
     expect(@another_user.events.length).to eq(1)
@@ -58,7 +58,7 @@ describe 'event jobs' do
     expect(@third_user.events.length).to eq(0)
     expect(Time).to receive(:now).at_least(:once).and_return(1)
     event = { action: 'User <a href="/users/jilluser@example-dot-com">jilluser@example.com</a> has unfollowed <a href="/users/archivist1@example-dot-com">archivist1@example.com</a>', timestamp: '1' }
-    UserUnfollowEventJob.new(@user.user_key, @another_user.user_key).run
+    UserUnfollowEventJob.perform_now(@user.user_key, @another_user.user_key)
     expect(@user.events.length).to eq(1)
     expect(@user.events.first).to eq(event)
     expect(@another_user.events.length).to eq(1)
@@ -77,7 +77,7 @@ describe 'event jobs' do
     expect(@fs.events.length).to eq(0)
     expect(Time).to receive(:now).at_least(:once).and_return(1)
     event = { action: 'User <a href="/users/jilluser@example-dot-com">jilluser@example.com</a> has deposited <a href="/files/test-123">Hamlet</a>', timestamp: '1' }
-    ContentDepositEventJob.new('test-123', @user.user_key).run
+    ContentDepositEventJob.perform_now('test-123', @user.user_key)
     expect(@user.profile_events.length).to eq(1)
     expect(@user.profile_events.first).to eq(event)
     expect(@another_user.events.length).to eq(1)
@@ -93,7 +93,7 @@ describe 'event jobs' do
     allow_any_instance_of(User).to receive(:can?).and_return(true)
     allow(Time).to receive(:now).at_least(:once).and_return(1)
     event = { action: 'User <a href="/users/jilluser@example-dot-com">jilluser@example.com</a> has transferred <a href="/works/test-456">BethsMac</a> to user <a href="/users/archivist1@example-dot-com">archivist1@example.com</a>', timestamp: '1' }
-    ContentDepositorChangeEventJob.new('test-456', @another_user.user_key).run
+    ContentDepositorChangeEventJob.perform_now('test-456', @another_user.user_key)
     expect(@user.profile_events.length).to eq(1)
     expect(@user.profile_events.first).to eq(event)
     expect(@another_user.events.length).to eq(1)
@@ -114,7 +114,7 @@ describe 'event jobs' do
     expect(@fs.events.length).to eq(0)
     expect(Time).to receive(:now).at_least(:once).and_return(1)
     event = { action: 'User <a href="/users/jilluser@example-dot-com">jilluser@example.com</a> has updated <a href="/files/test-123">Hamlet</a>', timestamp: '1' }
-    ContentUpdateEventJob.new('test-123', @user.user_key).run
+    ContentUpdateEventJob.perform_now('test-123', @user.user_key)
     expect(@user.profile_events.length).to eq(1)
     expect(@user.profile_events.first).to eq(event)
     expect(@another_user.events.length).to eq(1)
@@ -135,7 +135,7 @@ describe 'event jobs' do
     expect(@fs.events.length).to eq(0)
     expect(Time).to receive(:now).at_least(:once).and_return(1)
     event = { action: 'User <a href="/users/jilluser@example-dot-com">jilluser@example.com</a> has added a new version of <a href="/files/test-123">Hamlet</a>', timestamp: '1' }
-    ContentNewVersionEventJob.new('test-123', @user.user_key).run
+    ContentNewVersionEventJob.perform_now('test-123', @user.user_key)
     expect(@user.profile_events.length).to eq(1)
     expect(@user.profile_events.first).to eq(event)
     expect(@another_user.events.length).to eq(1)
@@ -156,7 +156,7 @@ describe 'event jobs' do
     expect(@fs.events.length).to eq(0)
     expect(Time).to receive(:now).at_least(:once).and_return(1)
     event = { action: 'User <a href="/users/jilluser@example-dot-com">jilluser@example.com</a> has restored a version \'content.0\' of <a href="/files/test-123">Hamlet</a>', timestamp: '1' }
-    ContentRestoredVersionEventJob.new('test-123', @user.user_key, 'content.0').run
+    ContentRestoredVersionEventJob.perform_now('test-123', @user.user_key, 'content.0')
     expect(@user.profile_events.length).to eq(1)
     expect(@user.profile_events.first).to eq(event)
     expect(@another_user.events.length).to eq(1)
@@ -175,7 +175,7 @@ describe 'event jobs' do
     expect(@third_user.events.length).to eq(0)
     expect(Time).to receive(:now).at_least(:once).and_return(1)
     event = { action: 'User <a href="/users/jilluser@example-dot-com">jilluser@example.com</a> has deleted file \'test-123\'', timestamp: '1' }
-    ContentDeleteEventJob.new('test-123', @user.user_key).run
+    ContentDeleteEventJob.perform_now('test-123', @user.user_key)
     expect(@user.profile_events.length).to eq(1)
     expect(@user.profile_events.first).to eq(event)
     expect(@another_user.events.length).to eq(1)
@@ -194,7 +194,7 @@ describe 'event jobs' do
     @now = Time.now
     expect(Time).to receive(:now).at_least(:once).and_return(@now)
     event = { action: 'User <a href="/users/jilluser@example-dot-com">jilluser@example.com</a> has updated <a href="/files/test-123">Hamlet</a>', timestamp: @now.to_i.to_s }
-    ContentUpdateEventJob.new('test-123', @user.user_key).run
+    ContentUpdateEventJob.perform_now('test-123', @user.user_key)
     expect(@user.profile_events.length).to eq(1)
     expect(@user.profile_events.first).to eq(event)
     expect(@another_user.events.length).to eq(0)

--- a/spec/models/generic_work_spec.rb
+++ b/spec/models/generic_work_spec.rb
@@ -19,9 +19,7 @@ describe GenericWork do
 
     it "transfers the request" do
       work.on_behalf_of = transfer_to.user_key
-      stub_job = double('change depositor job')
-      allow(ContentDepositorChangeEventJob).to receive(:new).and_return(stub_job)
-      expect(CurationConcerns.queue).to receive(:push).with(stub_job).once.and_return(true)
+      expect(ContentDepositorChangeEventJob).to receive(:perform_later).once
       work.save!
     end
   end

--- a/sufia-models/app/models/concerns/sufia/proxy_deposit.rb
+++ b/sufia-models/app/models/concerns/sufia/proxy_deposit.rb
@@ -16,7 +16,7 @@ module Sufia
     end
 
     def create_transfer_request
-      CurationConcerns.queue.push(ContentDepositorChangeEventJob.new(id, on_behalf_of)) if on_behalf_of.present?
+      ContentDepositorChangeEventJob.perform_later(id, on_behalf_of) if on_behalf_of.present?
     end
 
     def request_transfer_to(target)

--- a/sufia-models/app/models/proxy_deposit_request.rb
+++ b/sufia-models/app/models/proxy_deposit_request.rb
@@ -56,7 +56,7 @@ class ProxyDepositRequest < ActiveRecord::Base
 
   # @param [Boolean] reset (false) should the access controls be reset. This means revoking edit access from the depositor
   def transfer!(reset = false)
-    CurationConcerns.queue.push(ContentDepositorChangeEventJob.new(generic_work_id, receiving_user.user_key, reset))
+    ContentDepositorChangeEventJob.perform_later(generic_work_id, receiving_user.user_key, reset)
     self.status = 'accepted'
     self.fulfillment_date = Time.now
     save!

--- a/sufia-models/lib/tasks/sufia-models_tasks.rake
+++ b/sufia-models/lib/tasks/sufia-models_tasks.rake
@@ -1,6 +1,6 @@
 namespace :solr do
   desc "Enqueue a job to resolrize the repository objects"
   task reindex: :environment do
-    CurationConcerns.queue.push(ResolrizeJob.new)
+    ResolrizeJob.perform_later
   end
 end


### PR DESCRIPTION
Convert EventJob to inherit from ActiveJob::Base
Update EventJob subclasses for ActiveJob.
Refactor callback blocks for jobs.
  Use perform_later instead of queue.push
Refactor events spec for ActiveJob queueing
Remove CurationConcerns.queue in specs.

Addresses #106 