### PR TITLE
Use the new mime_type solr field from Curation Concerns

### DIFF
--- a/app/models/concerns/sufia/solr_document_behavior.rb
+++ b/app/models/concerns/sufia/solr_document_behavior.rb
@@ -89,10 +89,6 @@ module Sufia
       Array(self[Solrizer.solr_name("resource_type")])
     end
 
-    def mime_type
-      Array(self[Solrizer.solr_name("mime_type")]).first
-    end
-
     def read_groups
       Array(self[::Ability.read_group_field])
     end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -30,7 +30,7 @@ describe SolrDocument, type: :model do
     context "when mime-type is 'office'" do
       it "is office document" do
         Mimes.office_document_mime_types.each do |type|
-          subject['mime_type_tesim'] = [type]
+          subject['mime_type_ssi'] = type
           expect(subject).to be_office_document
         end
       end
@@ -39,7 +39,7 @@ describe SolrDocument, type: :model do
     describe "when mime-type is 'video'" do
       it "is office" do
         Mimes.video_mime_types.each do |type|
-          subject['mime_type_tesim'] = [type]
+          subject['mime_type_ssi'] = type
           expect(subject).to be_video
         end
       end


### PR DESCRIPTION
Use the new mime_type solr field (mime_type_ssi rather than mime_type_tesim) from Curation Concerns. 

I am removing the `mime_type` method in Sufia to be clear that we are using the one from Curation Concerns. 

This is now ready to be merged. It does not require any changes in Curation Concerns (i.e. https://github.com/projecthydra-labs/curation_concerns/pull/450 has been closed)