### PR TITLE
Force to use jcoyne's fork of Kaminari

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,8 @@ source 'https://rubygems.org'
 # Please see sufia.gemspec for dependency information.
 gemspec
 
+# Required for doing pagination inside an engine. See https://github.com/amatsuda/kaminari/pull/322
+gem 'kaminari', github: 'jcoyne/kaminari', branch: 'sufia'
 gem 'sufia-models', path: './sufia-models'
 gem 'slop', '~> 3.6.0' # This just helps us generate a valid Gemfile.lock when Rails 4.2 is installed (which requires byebug which has a dependency on slop)
 


### PR DESCRIPTION
Not sure why this would be needed. Posting this PR mostly to gather ideas. 

Without manually injecting the routes for users 

```
resources :users, only: [:index, :show, :edit, :update]
```

I get the following error when running test `rspec ./spec/views/users/index.html.erb_spec.rb`

```
1) users/index.html.erb draws user list
     Failure/Error: render
     ActionView::Template::Error:
       No route matches {:action=>"index", :controller=>"users", :page=>nil}
```
