### PR TITLE
Not all batches are UploadSets.

### DIFF
--- a/app/controllers/concerns/sufia/my_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/my_controller_behavior.rb
@@ -39,17 +39,17 @@ module Sufia
                               end
       @filters = params[:f] || []
 
-      # set up some parameters for allowing the batch controls to show appropiately
-      @max_upload_set_size = 80
+      # set up some parameters for allowing the batch controls to show appropriately
+      @max_batch_size = 80
       count_on_page = @document_list.count { |doc| batch.index(doc.id) }
-      @disable_select_all = @document_list.count > @max_upload_set_size
-      upload_set_size = batch.uniq.size
+      @disable_select_all = @document_list.count > @max_batch_size
+      batch_size = batch.uniq.size
       @result_set_size = @response.response["numFound"]
       @empty_batch = batch.empty?
       @all_checked = (count_on_page == @document_list.count)
-      @entire_result_set_selected = @response.response["numFound"] == upload_set_size
-      @upload_set_size_on_other_page = upload_set_size - count_on_page
-      @batch_part_on_other_page = (@upload_set_size_on_other_page) > 0
+      @entire_result_set_selected = @response.response["numFound"] == batch_size
+      @batch_size_on_other_page = batch_size - count_on_page
+      @batch_part_on_other_page = (@batch_size_on_other_page) > 0
 
       respond_to do |format|
         format.html {}

--- a/spec/helpers/batch_edits_helper_spec.rb
+++ b/spec/helpers/batch_edits_helper_spec.rb
@@ -4,8 +4,8 @@ describe BatchEditsHelper, type: :helper do
   describe "#render_check_all" do
     before do
       @document_list = ["doc1", "doc2"]
-      @upload_set_size_on_other_page = 1
-      @max_upload_set_size = 10
+      @batch_size_on_other_page = 1
+      @max_batch_size = 10
     end
 
     context "with my files" do

--- a/spec/views/batch_edits/check_all_spec.rb
+++ b/spec/views/batch_edits/check_all_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 describe 'Check All', type: :view do
   before(:all) do
     @document_list = ['a', 'b', 'c']
-    @upload_set_size_on_other_page = 0
-    @max_upload_set_size = 100
+    @batch_size_on_other_page = 0
+    @max_batch_size = 100
   end
 
   it 'renders batch edits actions' do


### PR DESCRIPTION
Reverts part of #102
Fixes Javascript SyntaxErrors under Poltergeist JS 1.9.8 due to an
undefined ivar:

```js
window.batch_size_on_other_page = ;
```