### PR TITLE
Calls the correct finder active-fedora method (find_in_batches)

### DIFF
--- a/spec/lib/sufia/user_stat_importer_spec.rb
+++ b/spec/lib/sufia/user_stat_importer_spec.rb
@@ -12,21 +12,21 @@ describe Sufia::UserStatImporter do
   let!(:gollum) { FactoryGirl.create(:user, email: 'gollum@example.com') }
 
   let!(:bilbo_file_1) do
-    FileSet.new(id: 'bilbo1').tap do |f|
+    FileSet.new(id: 'xyzbilbo1', title: ['bilbo 1']).tap do |f|
       f.apply_depositor_metadata(bilbo.email)
       f.save
     end
   end
 
   let!(:bilbo_file_2) do
-    FileSet.new(id: 'bilbo2').tap do |f|
+    FileSet.new(id: 'xyzbilbo2', title: ['bilbo 2']).tap do |f|
       f.apply_depositor_metadata(bilbo.email)
       f.save
     end
   end
 
   let!(:frodo_file_1) do
-    FileSet.new(id: 'frodo1').tap do |f|
+    FileSet.new(id: 'xyzfrodo1', title: ['frodo 1']).tap do |f|
       f.apply_depositor_metadata(frodo.email)
       f.save
     end

--- a/sufia-models/lib/sufia/models/stats/user_stat_importer.rb
+++ b/sufia-models/lib/sufia/models/stats/user_stat_importer.rb
@@ -58,7 +58,7 @@ module Sufia
 
       def file_ids_for_user(user)
         ids = []
-        ::FileSet.find_in_upload_sets("#{Solrizer.solr_name('depositor', :symbol)}:\"#{user.user_key}\"", fl: "id") do |group|
+        ::FileSet.find_in_batches("#{Solrizer.solr_name('depositor', :symbol)}:\"#{user.user_key}\"", fl: "id") do |group|
           ids.concat group.map { |doc| doc["id"] }
         end
         ids


### PR DESCRIPTION
At one point the code was updated to call `find_in_upload_sets` instead of `find_in_batches`. However the correct Active Fedora method in this case is `find_in_batches` as the word "batches" in this context refers to a group of records, not a Sufia Batch.