### PR TITLE
Uses the proper text to validate the test.

### DIFF
--- a/spec/lib/sufia/messages_spec.rb
+++ b/spec/lib/sufia/messages_spec.rb
@@ -22,10 +22,10 @@ describe Sufia::Messages do
 
   describe "message subjects" do
     it "provides a subject for a success message" do
-      expect(message.success_subject).to eq("UploadSet.upload complete")
+      expect(message.success_subject).to eq("Batch upload complete")
     end
     it "provides a subject for a failure message" do
-      expect(message.failure_subject).to eq("UploadSet.upload permission denied")
+      expect(message.failure_subject).to eq("Batch upload permission denied")
     end
   end
 


### PR DESCRIPTION
I suspect this was an overlook when replacing `Batch` with `UploadSet`. I decided to restore the original text (Batch) but I could instead update the value in `sufia.en.yml` to return "UploadSet" if others think that would be more appropriate.

