### PR TITLE
Allows to call clear_permissions! on works

### DIFF
--- a/sufia-models/app/models/concerns/sufia/generic_work_behavior.rb
+++ b/sufia-models/app/models/concerns/sufia/generic_work_behavior.rb
@@ -3,5 +3,6 @@ module Sufia
     extend ActiveSupport::Concern
     include Sufia::ProxyDeposit
     include Sufia::Works::Trophies
+    include Sufia::Permissions::Writable
   end
 end


### PR DESCRIPTION
ContentDepositorChangeEventJob issues a call to `work.clear_permissions!` 

Importing include Sufia::Permissions::Writable makes the method available.

Fixes #244 