### PR TITLE
Generate HydraEditor::Forms::Permissions include

### DIFF
--- a/lib/generators/sufia/install_generator.rb
+++ b/lib/generators/sufia/install_generator.rb
@@ -109,6 +109,9 @@ module Sufia
       file_path = "app/forms/curation_concerns/generic_work_form.rb"
       if File.exist?(file_path)
         gsub_file file_path, /CurationConcerns::Forms::WorkForm/, "Sufia::Forms::WorkForm"
+        inject_into_file file_path, after: /model_class = ::GenericWork/ do
+            "\n    include HydraEditor::Form::Permissions\n"
+        end
       else
         puts "     \e[31mFailure\e[0m  Sufia requires a GenericWorkForm object. This generator assumes that the model is defined in the file #{file_path}, which does not exist."
       end

--- a/spec/controllers/generic_works_controller_spec.rb
+++ b/spec/controllers/generic_works_controller_spec.rb
@@ -14,4 +14,15 @@ describe CurationConcerns::GenericWorksController do
       expect(assigns[:curation_concern]).to be_kind_of GenericWork
     end
   end
+
+  describe "#edit" do
+    let(:work) { create(:work, user: user) }
+
+    it "is successful" do
+      get :edit, id: work
+      expect(response).to be_successful
+      expect(response).to render_template("layouts/sufia-one-column")
+      expect(assigns[:form]).to be_kind_of CurationConcerns::GenericWorkForm
+    end
+  end
 end


### PR DESCRIPTION
Onto the CurationConcernGenericWorkForm. This enables the form to show
nested permissions attributes, e.g. edit_groups, read_users, etc.

Fixes #254 