### PR TITLE
Makes sure the expression in with the ternary operator (?) 

### DIFF
--- a/app/services/sufia/collection_size_service.rb
+++ b/app/services/sufia/collection_size_service.rb
@@ -19,8 +19,9 @@ module Sufia
     def collection_size
       query = collection_search_builder.rows(max_collection_size).merge(fl: [size_field])
       resp = repository.search(query)
+      field_name = size_field
       resp.documents.reduce(0) do |total, doc|
-        total + doc[size_field].blank? ? 0 : doc[size_field][0].to_f
+        total + (doc[field_name].blank? ? 0 : doc[field_name][0].to_f)
       end
     end
 


### PR DESCRIPTION
Makes sure the expression with the ternary operator (?) is evaluated properly. Without the parenthesis it was evaluating incorrectly and trying to add a Boolean to a float.

Fixes #252 