### PR TITLE
Generate term resource_type onto the GenericWorkForm

### DIFF
--- a/lib/generators/sufia/install_generator.rb
+++ b/lib/generators/sufia/install_generator.rb
@@ -110,7 +110,8 @@ module Sufia
       if File.exist?(file_path)
         gsub_file file_path, /CurationConcerns::Forms::WorkForm/, "Sufia::Forms::WorkForm"
         inject_into_file file_path, after: /model_class = ::GenericWork/ do
-          "\n    include HydraEditor::Form::Permissions\n"
+          "\n    include HydraEditor::Form::Permissions" \
+          "\n    self.terms += [:resource_type]\n"
         end
       else
         puts "     \e[31mFailure\e[0m  Sufia requires a GenericWorkForm object. This generator assumes that the model is defined in the file #{file_path}, which does not exist."

--- a/spec/views/curation_concerns/base/_form.html.erb_spec.rb
+++ b/spec/views/curation_concerns/base/_form.html.erb_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'curation_concerns/base/_form.html.erb', :no_clean do
-  describe 'when the file has two or more resource types' do
+  describe 'when the work has two or more resource types' do
     let(:work) do
       stub_model(GenericWork, id: '456')
     end
@@ -24,7 +24,7 @@ describe 'curation_concerns/base/_form.html.erb', :no_clean do
     end
 
     it "only draws one resource_type multiselect" do
-      expect(page).to have_selector("select#file_set_resource_type", count: 1)
+      expect(page).to have_selector("select#generic_work_resource_type", count: 1)
     end
   end
 end


### PR DESCRIPTION
Fixes test error:
```
curation_concerns/base/_form.html.erb when the file has two or more resource types only draws one resource_type multiselect

      Failure/Error: expect(page).to have_selector("select#file_set_resource_type", count: 1)

        expected to find css "select#file_set_resource_type" 1 time but there were no matches
```