### PR TITLE
Render page_title on the layout

### DIFF
--- a/app/views/curation_concerns/file_sets/edit.html.erb
+++ b/app/views/curation_concerns/file_sets/edit.html.erb
@@ -1,6 +1,6 @@
 <% provide :page_title, curation_concern_page_title(curation_concern) %>
 <% provide :page_header do %>
-  <h1>Updating Attached File to <span class="parent_container">"<%= parent %>"<span></h1>
+  <h1 class="lower">Edit <%= curation_concern %></h1>
 <% end %>
 
 <div class="row">

--- a/app/views/layouts/sufia-one-column.html.erb
+++ b/app/views/layouts/sufia-one-column.html.erb
@@ -12,6 +12,13 @@
       <%= render partial: '/controls' %>
       <%= render partial: '/flash_msg' %>
       <div id="content-wrapper" class="container-fluid">
+        <% if content_for?(:page_header) %>
+          <div class="row">
+            <div class="col-xs-12 main-header">
+              <%= yield(:page_header) %>
+            </div>
+          </div>
+        <% end %>
         <div id="content" class="row">
           <div class="col-xs-12">
             <%= yield %>

--- a/spec/factories/generic_works.rb
+++ b/spec/factories/generic_works.rb
@@ -7,7 +7,7 @@ FactoryGirl.define do
     title ["Test title"]
     visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
 
-    before(:create) do |work, evaluator|
+    after(:build) do |work, evaluator|
       work.apply_depositor_metadata(evaluator.user.user_key)
     end
 

--- a/spec/features/edit_file_spec.rb
+++ b/spec/features/edit_file_spec.rb
@@ -3,18 +3,21 @@ require 'spec_helper'
 describe "Editing a file:", type: :feature do
   let(:user) { create(:user) }
   let(:file_title) { 'Some kind of title' }
-  let(:work) { create(:work_with_one_file, user: user) }
+  let(:work) { build(:work, user: user) }
   let(:file) { work.members.first }
 
-  before { sign_in user }
+  before do
+    sign_in user
+    work.ordered_members << create(:file_set, user: user, title: [file_title], filename: 'filename.pdf')
+    work.save!
+  end
 
   context 'when the user tries to update file content, but forgets to select a file:' do
-    it 'displays an error' do
+    it 'shows the edit page again' do
       visit edit_curation_concerns_file_set_path(file)
       click_link 'Versions'
       click_button 'Upload New Version'
       expect(page).to have_content "Edit #{file_title}"
-      expect(page).to have_content 'Please select a file'
     end
   end
 end


### PR DESCRIPTION
Removed check for an error when they don't add a file, because this
controller is responsible for updating both file content and metadata.  If
they don't supply a file, it just updates the metadata, and no error
is created.
Ref #169
Fixes #269