### PR TITLE
Make my controller retrieve only user's own collections.

### DIFF
--- a/app/controllers/concerns/sufia/my_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/my_controller_behavior.rb
@@ -17,6 +17,7 @@ module Sufia
       before_action :enforce_show_permissions, only: :show
       before_action :enforce_viewing_context_for_show_requests, only: :show
       before_action :find_collections, only: :index
+      before_action :find_collections_with_edit_access, only: :index
 
       self.search_params_logic += [:add_access_controls_to_solr_params, :add_advanced_parse_q_to_solr]
 

--- a/spec/controllers/my/files_controller_spec.rb
+++ b/spec/controllers/my/files_controller_spec.rb
@@ -48,6 +48,8 @@ describe My::FilesController, type: :controller do
       end
     end
 
+    let!(:other_collection) { create(:collection) }
+
     let!(:my_work) { create(:work, user: user) }
     let!(:shared_work) { create(:work, edit_users: [user.user_key], user: someone_else) }
     let!(:unrelated_work) { create(:public_work, user: someone_else) }
@@ -70,6 +72,9 @@ describe My::FilesController, type: :controller do
       # doesn't show non-works
       expect(doc_ids).to_not include(wrong_type.id)
       expect(doc_ids).to_not include(my_file.id)
+
+      # Only has collections that I own.
+      expect(assigns[:user_collections].map(&:id)).to eq [my_collection.id]
     end
   end # context 'with different types of records'
 end


### PR DESCRIPTION
My controller used to get all collections from the system rather
than just the ones belonging to the user. When adding files to
a collection, this would give the user a list of all collections
to choose from. The user couldn't add the files to someone else's
collection anyway so those options were useless.