### PR TITLE
Use ActiveFedora::Noid 1.0 and surface its config in the Sufia config.

### DIFF
--- a/sufia-models/lib/generators/sufia/models/templates/config/sufia.rb
+++ b/sufia-models/lib/generators/sufia/models/templates/config/sufia.rb
@@ -94,6 +94,13 @@ Sufia.config do |config|
   # Specify a different template for your repository's NOID IDs
   # config.noid_template = ".reeddeeddk"
 
+  # Store identifier minter's state in a file for later replayability
+  # config.minter_statefile = '/tmp/minter-state'
+
+  # Process for translating Fedora URIs to identifiers and vice versa
+  # config.translate_uri_to_id = ActiveFedora::Noid.config.translate_uri_to_id
+  # config.translate_id_to_uri = ActiveFedora::Noid.config.translate_id_to_uri
+
   # Specify the prefix for Redis keys:
   # config.redis_namespace = "sufia"
 

--- a/sufia-models/lib/sufia/models/engine.rb
+++ b/sufia-models/lib/sufia/models/engine.rb
@@ -10,6 +10,7 @@ module Sufia
 
     class Engine < ::Rails::Engine
       require 'curation_concerns'
+      require 'active_fedora/noid'
 
       # Set some configuration defaults
       config.persistent_hostpath = "http://localhost/files/"
@@ -17,9 +18,6 @@ module Sufia
       config.ffmpeg_path = 'ffmpeg'
       config.fits_message_length = 5
       config.temp_file_base = nil
-      config.enable_noids = true
-      config.noid_template = '.reeddeeddk'
-      config.minter_statefile = '/tmp/minter-state'
       config.redis_namespace = "sufia"
       config.fits_path = "fits.sh"
       config.enable_contact_form_delivery = false
@@ -30,6 +28,13 @@ module Sufia
       config.max_notifications_for_dashboard = 5
       config.activity_to_show_default_seconds_since_now = 24 * 60 * 60
       config.arkivo_api = false
+
+      # Noid identifiers
+      config.enable_noids = true
+      config.noid_template = '.reeddeeddk'
+      config.minter_statefile = '/tmp/minter-state'
+      config.translate_uri_to_id = ActiveFedora::Noid.config.translate_uri_to_id
+      config.translate_id_to_uri = ActiveFedora::Noid.config.translate_id_to_uri
 
       # Defaulting analytic start date to whenever the file was uploaded by leaving it blank
       config.analytic_start_date = nil
@@ -65,8 +70,8 @@ module Sufia
           Hydra::Derivatives.fits_path      = c.fits_path
           Hydra::Derivatives.enable_ffmpeg  = c.enable_ffmpeg
 
-          ActiveFedora::Base.translate_uri_to_id = ActiveFedora::Noid.config.translate_uri_to_id
-          ActiveFedora::Base.translate_id_to_uri = ActiveFedora::Noid.config.translate_id_to_uri
+          ActiveFedora::Base.translate_uri_to_id = c.translate_uri_to_id
+          ActiveFedora::Base.translate_id_to_uri = c.translate_id_to_uri
           ActiveFedora::Noid.config.template = c.noid_template
           ActiveFedora::Noid.config.statefile = c.minter_statefile
         end

--- a/sufia-models/lib/tasks/sufia-models_tasks.rake
+++ b/sufia-models/lib/tasks/sufia-models_tasks.rake
@@ -1,3 +1,7 @@
+# Pull in tasks from AF::Noid
+af_noid = Gem::Specification.find_by_name 'active_fedora-noid'
+load "#{af_noid.gem_dir}/lib/tasks/noid_tasks.rake"
+
 namespace :solr do
   desc "Enqueue a job to resolrize the repository objects"
   task reindex: :environment do
@@ -6,6 +10,14 @@ namespace :solr do
 end
 
 namespace :sufia do
+  namespace :noid do
+    desc 'Migrate minter state file'
+    task migrate_statefile: :environment do
+      ENV['AFNOID_STATEFILE'] = Sufia.config.minter_statefile
+      Rake::Task['active_fedora:noid:migrate_statefile'].invoke if needs_migration?(Sufia.config.minter_statefile)
+    end
+  end
+
   namespace :user do
     desc 'Populate user tokens'
     task tokens: :environment do
@@ -19,4 +31,10 @@ namespace :sufia do
       end
     end
   end
+end
+
+def needs_migration?(statefile)
+  !!YAML.load(File.open(statefile).read)
+rescue Psych::SyntaxError, Errno::ENOENT
+  false
 end

--- a/tasks/sufia-dev.rake
+++ b/tasks/sufia-dev.rake
@@ -20,9 +20,15 @@ end
 desc 'Spin up hydra-jetty and run specs'
 task ci: ['engine_cart:generate', 'jetty:clean', 'curation_concerns:jetty:config'] do
   puts 'running continuous integration'
+  # No need to maintain minter state on Travis
+  reset_statefile! if ENV['TRAVIS'] == 'true'
   jetty_params = Jettywrapper.load_config
   error = Jettywrapper.wrap(jetty_params) do
     Rake::Task['spec'].invoke
   end
   raise "test failures: #{error}" if error
 end
+
+ def reset_statefile!
+   FileUtils.rm_f('/tmp/minter-state')
+ end


### PR DESCRIPTION
Add a rake task that knows how to migrate prior Sufia minter statefiles, and ignore prior minter state in Travis CI environment.