### PR TITLE
Fix sorting issues with collections.

### DIFF
--- a/app/assets/stylesheets/sufia/_file-listing.scss
+++ b/app/assets/stylesheets/sufia/_file-listing.scss
@@ -105,6 +105,11 @@ h4 .small {
   display: none;
 }
 
+.visibility-link .label {
+  font-size: .85em;
+  font-weight: normal;
+}
+
 .visibility-link:hover {
   text-decoration: none;
 }

--- a/app/controllers/concerns/sufia/my_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/my_controller_behavior.rb
@@ -53,6 +53,8 @@ module Sufia
       @batch_size_on_other_page = batch_size - count_on_page
       @batch_part_on_other_page = (@batch_size_on_other_page) > 0
 
+      @add_files_to_collection = params.fetch(:add_files_to_collection, '')
+
       respond_to do |format|
         format.html {}
         format.rss  { render layout: false }

--- a/app/models/concerns/sufia/solr_document_behavior.rb
+++ b/app/models/concerns/sufia/solr_document_behavior.rb
@@ -17,8 +17,14 @@ module Sufia
       get(Solrizer.solr_name('has_model', :symbol)).split(':').last.downcase
     end
 
+    # Date created indexed as a string. This allows users to enter values like: 'Circa 1840-1844'
+    # This overrides the default behavior of CurationConcerns which indexes a date
     def date_created
       self[Solrizer.solr_name("date_created")]
+    end
+
+    def create_date
+      date_field('system_create')
     end
 
     # TODO: Move to curation_concerns?

--- a/app/views/collections/_form_for_select_collection.html.erb
+++ b/app/views/collections/_form_for_select_collection.html.erb
@@ -13,9 +13,10 @@
               <fieldset>
                 <legend><%= t("sufia.collection.select_form.select_heading") %></legend>
               <ul>
-                <% user_collections.sort { |c1,c2| c1['date_modified_dtsi'] <=> c2['date_modified_dtsi'] }.each do |collection|  %>
+                <% user_collections.sort { |c1,c2| c2[CatalogController.uploaded_field] <=> c1[CatalogController.uploaded_field] }.each_with_index do |collection,index|  %>
                   <li>
-                    <%= radio_button_tag(:id, collection.id, true, class: "collection-selector") %>
+                    <% selected = (collection.id == @add_files_to_collection) || (@add_files_to_collection.blank? && index == 0) %>
+                    <%= radio_button_tag(:id, collection.id, selected, class: "collection-selector") %>
                     <%= label_tag(:collection, collection.title, for: "id_#{collection.id}") %>
                   </li>
                 <% end %>
@@ -28,10 +29,10 @@
           <button type="button" class="btn btn-default" data-dismiss="modal"><%= t("sufia.collection.select_form.close")%></button>
           <% if user_collections.blank? %>
             <%= button_for_create_collection t("sufia.collection.select_form.create") %>
-          <% else %> 
+          <% else %>
             <%= button_for_update_collection t("sufia.collection.select_form.update") %>
             <%= button_for_create_collection t("sufia.collection.select_form.create_new") %>
-          <% end %> 
+          <% end %>
         </div>
       </div><!-- /.modal-content -->
   </div><!-- /.modal-dialog -->

--- a/app/views/collections/_show_actions.html.erb
+++ b/app/views/collections/_show_actions.html.erb
@@ -1,6 +1,7 @@
 <h2 class="sr-only">Actions</h2>
 <div class="actions-controls-collections">
-  <% if can? :edit, @collection %>
-      <span class="label label-default"><%= link_to "Edit", collections.edit_collection_path, title: "Edit this Collection" %></span> &nbsp;&nbsp;
+  <% if can? :edit, @presenter.solr_document %>
+    <span class="label label-default"><%= link_to "Edit", collections.edit_collection_path, title: "Edit this Collection" %></span> &nbsp;&nbsp;
+    <span class="label label-default"><%= link_to "Add files",  sufia.dashboard_files_path(add_files_to_collection: @presenter.id), title: "Add files to this Collection" %></span>
   <%end %>
 </div>

--- a/app/views/my/_index_partials/_default_group.html.erb
+++ b/app/views/my/_index_partials/_default_group.html.erb
@@ -5,7 +5,7 @@
   <tr>
     <th><label for="check_all" class="sr-only"><%= t("sufia.dashboard.my.sr.check_all_label") %></label><%= render_check_all %></th>
     <th>Title</th>
-    <th class="sorts-dash"><i id="date_uploaded_dtsi" class="<%=params[:sort]== "date_uploaded_dtsi desc" ? 'caret' : params[:sort]== "date_uploaded_dtsi asc" ? 'caret up' : ''%>"></i>Date Uploaded</th>
+    <th class="sorts-dash"><i id="<%= CatalogController.uploaded_field %>" class="<%=params[:sort]== "#{CatalogController.uploaded_field} desc" ? 'caret' : params[:sort]== "#{CatalogController.uploaded_field} asc" ? 'caret up' : ''%>"></i>Date Uploaded</th>
     <th>Visibility</th>
     <th>Action</th>
   </tr>

--- a/app/views/my/_index_partials/_list_collections.html.erb
+++ b/app/views/my/_index_partials/_list_collections.html.erb
@@ -21,7 +21,7 @@
       </div>
     </div>
   </td>
-  <td width="17%"><%= document.date_uploaded %> </td>
+  <td width="17%" class="text-center"><%= document.create_date %> </td>
   <td width="5%" class="text-center">
       <% if document.registered? %>
      <span class="label label-info" title="<%=t('sufia.institution_name') %>"><%=t('sufia.institution_name') %></span></a>

--- a/app/views/my/_index_partials/_list_collections.html.erb
+++ b/app/views/my/_index_partials/_list_collections.html.erb
@@ -22,7 +22,7 @@
     </div>
   </td>
   <td width="17%" class="text-center"><%= document.create_date %> </td>
-  <td width="5%" class="text-center">
+  <td width="5%" class="text-center visibility-link">
       <% if document.registered? %>
      <span class="label label-info" title="<%=t('sufia.institution_name') %>"><%=t('sufia.institution_name') %></span></a>
     <% elsif document.public? %>

--- a/app/views/my/_index_partials/_list_files.html.erb
+++ b/app/views/my/_index_partials/_list_files.html.erb
@@ -31,7 +31,7 @@
       </div>
     </div>
   </td>
-  <td class="text-center"><%= document.date_uploaded %> </td>
+  <td class="text-center"><%= document.create_date %> </td>
   <td class="text-center">
     <%= render_visibility_link document %>
   </td>

--- a/app/views/my/_sort_and_per_page.html.erb
+++ b/app/views/my/_sort_and_per_page.html.erb
@@ -1,4 +1,4 @@
-<div class="batch-info"> 
+<div class="batch-info">
   <div>
     <%= render partial: 'collections/form_for_select_collection', locals: {user_collections: @user_collections}  %>
   </div>
@@ -13,7 +13,7 @@
 
   <div class="sort-toggle">
     <% unless @response.response['numFound'] < 2 %>
-      <%= form_tag sufia.dashboard_files_path, method: :get, class: 'per_page form-inline' do %>
+      <%= form_tag search_action_for_dashboard, method: :get, class: 'per_page form-inline' do %>
             <fieldset class="col-xs-12">
               <legend class="sr-only"><%= t('sufia.sort_label') %></legend>
               <%= label_tag(:sort, "<span>Sort By:</span>".html_safe) %>
@@ -31,5 +31,5 @@
       <% end %>
     <% end unless sort_fields.empty? %>
   </div>
-  
+
 </div>

--- a/lib/generators/sufia/templates/catalog_controller.rb
+++ b/lib/generators/sufia/templates/catalog_controller.rb
@@ -20,11 +20,11 @@ class CatalogController < ApplicationController
   skip_before_filter :default_html_head
 
   def self.uploaded_field
-    solr_name('date_uploaded', :stored_sortable, type: :date)
+    solr_name('system_create', :stored_sortable, type: :date)
   end
 
   def self.modified_field
-    solr_name('date_modified', :stored_sortable, type: :date)
+    solr_name('system_modified', :stored_sortable, type: :date)
   end
 
   configure_blacklight do |config|

--- a/spec/controllers/my/files_controller_spec.rb
+++ b/spec/controllers/my/files_controller_spec.rb
@@ -77,4 +77,9 @@ describe My::FilesController, type: :controller do
       expect(assigns[:user_collections].map(&:id)).to eq [my_collection.id]
     end
   end # context 'with different types of records'
+
+  it "sets add_files_to_collection when provided in params" do
+    get :index, add_files_to_collection: '12345'
+    expect(assigns(:add_files_to_collection)).to eql('12345')
+  end
 end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -8,6 +8,34 @@ describe ::SolrDocument, type: :model do
     it "is a date" do
       expect(subject.date_uploaded).to eq '03/14/2013'
     end
+    it "logs parse errors" do
+      expect(ActiveFedora::Base.logger).to receive(:info).with(/Unable to parse date.*/)
+      subject['date_uploaded_dtsi'] = 'Test'
+      subject.date_uploaded
+    end
+  end
+
+  describe "create_date" do
+    before do
+      subject['system_create_dtsi'] = '2013-03-14T00:00:00Z'
+    end
+    it "is a date" do
+      expect(subject.create_date).to eq '03/14/2013'
+    end
+    it "logs parse errors" do
+      expect(ActiveFedora::Base.logger).to receive(:info).with(/Unable to parse date.*/)
+      subject['system_create_dtsi'] = 'Test'
+      subject.create_date
+    end
+  end
+
+  describe "resource_type" do
+    before do
+      subject['resource_type_tesim'] = ['Image']
+    end
+    it "returns the resource type" do
+      expect(subject.resource_type).to eq ['Image']
+    end
   end
 
   describe '#to_param' do

--- a/spec/views/catalog/sort_and_per_page.html.erb_spec.rb
+++ b/spec/views/catalog/sort_and_per_page.html.erb_spec.rb
@@ -24,6 +24,6 @@ describe 'catalog/_sort_and_per_page.html.erb', type: :view do
 
   it 'displays the relevance option for sorting' do
     render
-    expect(rendered).to include("<li><a href=\"/catalog?sort=score+desc%2C+date_uploaded_dtsi+desc\">relevance</a></li>")
+    expect(rendered).to include("<li><a href=\"/catalog?sort=score+desc%2C+system_create_dtsi+desc\">relevance</a></li>")
   end
 end

--- a/spec/views/collections/_form_for_select_collection.html.erb_spec.rb
+++ b/spec/views/collections/_form_for_select_collection.html.erb_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+describe 'collections/_form_for_select_collection.html.erb' do
+  let(:collections) {
+    [
+      Collection.new(id: '1234', title: 'collection 1', create_date: DateTime.parse('Thu, 13 Aug 2015 14:20:22 +0100')),
+      Collection.new(id: '1235', title: 'collection 2', create_date: DateTime.parse('Thu, 13 Aug 2015 14:18:22 +0100')),
+      Collection.new(id: '1236', title: 'collection 3', create_date: DateTime.parse('Thu, 13 Aug 2015 14:16:22 +0100')),
+      Collection.new(id: '1237', title: 'collection 4', create_date: DateTime.parse('Thu, 13 Aug 2015 14:29:22 +0100'))
+    ]
+  }
+  let(:solr_collections) {
+    collections.map do |c|
+      SolrDocument.new(c.to_solr).tap do |sd|
+        sd['system_create_dtsi'] = c.create_date.to_s
+      end
+    end
+  }
+
+  let(:doc) {
+    Nokogiri::HTML(rendered)
+  }
+
+  before do
+    allow(view).to receive(:user_collections).and_return(solr_collections)
+  end
+
+  it "sorts the collections" do
+    render
+    collection_ids = doc.xpath("//input[@class='collection-selector']/@id").map(&:to_s)
+    expect(collection_ids).to eql(["id_1237", "id_1234", "id_1235", "id_1236"])
+  end
+
+  it "selects the right collection when instructed to do so" do
+    assign(:add_files_to_collection, collections[2].id)
+    render
+    expect(rendered).not_to have_selector "#id_#{collections[0].id}[checked='checked']"
+    expect(rendered).not_to have_selector "#id_#{collections[1].id}[checked='checked']"
+    expect(rendered).not_to have_selector "#id_#{collections[3].id}[checked='checked']"
+    expect(rendered).to have_selector "#id_#{collections[2].id}[checked='checked']"
+  end
+
+  it "selects the first collection when nothing else specified" do
+    # first when sorted by create date, so not index 0
+    render
+    expect(rendered).not_to have_selector "#id_#{collections[0].id}[checked='checked']"
+    expect(rendered).not_to have_selector "#id_#{collections[1].id}[checked='checked']"
+    expect(rendered).not_to have_selector "#id_#{collections[2].id}[checked='checked']"
+    expect(rendered).to have_selector "#id_#{collections[3].id}[checked='checked']"
+  end
+end


### PR DESCRIPTION
Uses system_modified_dtsi and system_create_dtsi for sorting instead
of date_uploaded_dtsi and date_modified_dtsi. This applies to both
collections and generic files.

Fix sorting and paging form in my/collections to point to back to
my/collections instead of my/files.

Also remember the collection id when selecting add files to collection
from collection page so that the right collection can be automatically
selected in the collection list.