### PR TITLE
Allows the developer to configure the frequency of the messages pingi…

### DIFF
--- a/app/assets/javascripts/notifications_check.js.erb
+++ b/app/assets/javascripts/notifications_check.js.erb
@@ -1,0 +1,46 @@
+Blacklight.onLoad(function() {
+
+  <% if Rails.env.development? %>
+
+    // During development allow the frequency of the notifications check to
+    // be overwritten via query string parameter notification_seconds to
+    // prevent cluttering the terminal with (mostly) meaninless messages.
+    function queryStringParam(key) {
+      var queryString, pairs, i;
+      var value = null;
+      try {
+        queryString = document.location.search.substring(1);
+        if (queryString === "") {
+          return value; // nothing to do
+        }
+        pairs = queryString.split("&").map(function(el) {
+          var pair = el.split("=");
+          return {key: pair[0], value: pair[1]};
+        });
+        for(i = 0; i < pairs.length; i++) {
+          if (pairs[i].key === key) {
+            value = pairs[i].value;
+            break;
+          }
+        };
+      }
+      catch(e) {
+        // assume it's a malformed query string.
+        value = null;
+      }
+      return value;
+    }
+
+    function getIntervalSeconds() {
+      var seconds = parseInt(queryStringParam("notification_seconds"));
+      return seconds || 30;
+    }
+
+    setInterval(notify_update_link, getIntervalSeconds() * 1000);
+
+  <% else %>
+
+    setInterval(notify_update_link, 30 * 1000);
+
+  <% end %>
+});

--- a/app/assets/javascripts/sufia.js
+++ b/app/assets/javascripts/sufia.js
@@ -28,6 +28,7 @@
 
 //= require batch_edit
 //= require terms_of_service
+//= require notifications_check
 //
 //= require sufia/app
 //= require sufia/fileupload
@@ -86,8 +87,6 @@ Blacklight.onLoad(function() {
 
   // set up global batch edit options to override the ones in the gem
   window.batch_edits_options = { checked_label: "",unchecked_label: "",progress_label: "",status_label: "",css_class: "batch_toggle"};
-
-  setInterval(notify_update_link, 30*1000);
 
   // bootstrap alerts are closed this function
   $(document).on('click', '.alert .close' , function(){


### PR DESCRIPTION
…ng the server to check for user notifications.

    The main goal of this commit is to allow the developer to remove the clutter of mostly useless messages in order to see the rest of the information that Rails logs by default (e.g. the controller hit on each request, the parameters sent, et cetera.)

    The default behavior is to ping the server every 30 seconds. By passing "?notification_seconds=120" the developer can request the ping to happen every 120 seconds instead.