### PR TITLE
Refactoring event jobs to remove the continuos copying of code.

### DIFF
--- a/app/jobs/content_delete_event_job.rb
+++ b/app/jobs/content_delete_event_job.rb
@@ -1,15 +1,20 @@
+# A specific job to log a file deletion to a user's activity stream
+#
+# @attr_reader deleted_work_id The id of the work that has been deleted by the user
 class ContentDeleteEventJob < EventJob
-  def perform(id, depositor_id)
-    action = "User #{link_to_profile depositor_id} has deleted file '#{id}'"
-    timestamp = Time.now.to_i
-    depositor = User.find_by_user_key(depositor_id)
-    # Create the event
-    event = depositor.create_event(action, timestamp)
-    # Log the event to the depositor's profile stream
+  attr_reader :deleted_work_id
+
+  def perform(deleted_work_id, depositor_id)
+    @deleted_work_id = deleted_work_id
+    super(depositor_id)
+  end
+
+  def action
+    @action ||= "User #{link_to_profile depositor_id} has deleted file '#{deleted_work_id}'"
+  end
+
+  # override to log the event to the users profile stream instead of the user's stream
+  def log_user_event
     depositor.log_profile_event(event)
-    # Fan out the event to all followers
-    depositor.followers.each do |follower|
-      follower.log_event(event)
-    end
   end
 end

--- a/app/jobs/content_deposit_event_job.rb
+++ b/app/jobs/content_deposit_event_job.rb
@@ -1,18 +1,6 @@
-class ContentDepositEventJob < EventJob
-  def perform(id, depositor_id)
-    fs = FileSet.find(id)
-    action = "User #{link_to_profile depositor_id} has deposited #{link_to fs.title.first, Rails.application.routes.url_helpers.curation_concerns_file_set_path(fs)}"
-    timestamp = Time.now.to_i
-    depositor = User.find_by_user_key(depositor_id)
-    # Create the event
-    event = depositor.create_event(action, timestamp)
-    # Log the event to the depositor's profile stream
-    depositor.log_profile_event(event)
-    # Log the event to the FS's stream
-    fs.log_event(event)
-    # Fan out the event to all followers who have access
-    depositor.followers.select { |user| user.can? :read, fs }.each do |follower|
-      follower.log_event(event)
-    end
+# A specific job to log a file deposit to a user's activity stream
+class ContentDepositEventJob < ContentEventJob
+  def action
+    "User #{link_to_profile depositor_id} has deposited #{link_to file_set.title.first, Rails.application.routes.url_helpers.curation_concerns_file_set_path(file_set)}"
   end
 end

--- a/app/jobs/content_depositor_change_event_job.rb
+++ b/app/jobs/content_depositor_change_event_job.rb
@@ -1,35 +1,70 @@
-class ContentDepositorChangeEventJob < EventJob
+# A specific job to log a file deposit change to a user's activity stream
+#
+# This is a bit wierd becuase the job performs the depositor transfer along with logging the job
+#
+# @attr [String] id identifier of the file to be transfered
+# @attr [String] login the user key of the user the file is being transfered to.
+# @attr [Boolean] reset (false) should the access controls be reset. This means revoking edit access from the depositor
+class ContentDepositorChangeEventJob < ContentEventJob
   queue_as :proxy_deposit
+
+  attr_accessor :generic_work_id, :login, :reset
 
   # @param [String] id identifier of the generic work to be transfered
   # @param [String] login the user key of the user the generic work is being transfered to.
   # @param [TrueClass,FalseClass] reset (false) if true, reset the access controls. This revokes edit access from the depositor
-  def perform(id, login, reset = false)
-    # TODO: This should be in its own job, not this event job
-    work = ::GenericWork.find(id)
-    work.proxy_depositor = work.depositor
-    work.permissions = [] if reset
-    work.apply_depositor_metadata(login)
-    work.file_sets.each do |f|
-      f.apply_depositor_metadata(login)
-      f.save!
-    end
-    work.save!
+  def perform(generic_work_id, login, reset = false)
+    @generic_work_id = generic_work_id
+    @login = login
+    @reset = reset
+    super(generic_work_id, login)
+  end
 
-    action = "User #{link_to_profile work.proxy_depositor} has transferred #{link_to work.title.first, Rails.application.routes.url_helpers.curation_concerns_generic_work_path(work)} to user #{link_to_profile login}"
-    timestamp = Time.now.to_i
-    depositor = ::User.find_by_user_key(work.depositor)
-    proxy_depositor = ::User.find_by_user_key(work.proxy_depositor)
-    # Create the event
-    event = proxy_depositor.create_event(action, timestamp)
-    # Log the event to the FS's stream
+  # create an event with an action and a timestamp for the user
+  def event
+    @event ||= proxy_depositor.create_event(action, Time.now.to_i)
+  end
+
+  def action
+    "User #{link_to_profile work.proxy_depositor} has transferred #{link_to work.title.first, Rails.application.routes.url_helpers.curation_concerns_generic_work_path(work)} to user #{link_to_profile login}"
+  end
+
+  # Log the event to the GenericWork's stream
+  def log_work_event
     work.log_event(event)
+  end
+  alias_method :log_file_set_event, :log_work_event
+
+  def work
+    @work ||= begin
+      # TODO: This should be in its own job, not this event job
+      work = ::GenericWork.find(generic_work_id)
+      work.proxy_depositor = work.depositor
+      work.permissions = [] if reset
+      work.apply_depositor_metadata(login)
+      work.file_sets.each do |f|
+        f.apply_depositor_metadata(login)
+        f.save!
+      end
+      work.save!
+      work
+    end
+  end
+
+  # overriding default to log the event to the depositor instead of their profile
+  def log_user_event
     # log the event to the proxy depositor's profile
     proxy_depositor.log_profile_event(event)
-    # log the event to the depositor's dashboard
     depositor.log_event(event)
-    # Fan out the event to the depositor's followers who have access
-    depositor.followers.select { |user| user.can? :read, work }.each do |follower|
+  end
+
+  def proxy_depositor
+    @proxy_depositor ||= ::User.find_by_user_key(work.proxy_depositor)
+  end
+
+  # override to check file permissions before logging to followers
+  def log_to_followers
+    depositor.followers.select { |user| user.can?(:read, work) }.each do |follower|
       follower.log_event(event)
     end
   end

--- a/app/jobs/content_event_job.rb
+++ b/app/jobs/content_event_job.rb
@@ -1,0 +1,34 @@
+# A generic job for sending events about a generic files to a user and their followers.
+#
+# @attr [String] file_set_id  the id of the file the event is specified for
+#
+class ContentEventJob < EventJob
+  attr_accessor :file_set_id
+
+  def perform(file_set_id, depositor_id)
+    @file_set_id = file_set_id
+    super(depositor_id)
+    log_file_set_event
+  end
+
+  def file_set
+    @file_set ||= FileSet.load_instance_from_solr(file_set_id)
+  end
+
+  # Log the event to the FileSet's stream
+  def log_file_set_event
+    file_set.log_event(event) unless file_set.nil?
+  end
+
+  # override to check file permissions before logging to followers
+  def log_to_followers
+    depositor.followers.select { |user| user.can?(:read, file_set) }.each do |follower|
+      follower.log_event(event)
+    end
+  end
+
+  # log the event to the users profile stream
+  def log_user_event
+    depositor.log_profile_event(event)
+  end
+end

--- a/app/jobs/content_new_version_event_job.rb
+++ b/app/jobs/content_new_version_event_job.rb
@@ -1,18 +1,6 @@
-class ContentNewVersionEventJob < EventJob
-  def perform(id, depositor_id)
-    fs = FileSet.find(id)
-    action = "User #{link_to_profile depositor_id} has added a new version of #{link_to fs.title.first, Rails.application.routes.url_helpers.curation_concerns_file_set_path(fs)}"
-    timestamp = Time.now.to_i
-    depositor = User.find_by_user_key(depositor_id)
-    # Create the event
-    event = depositor.create_event(action, timestamp)
-    # Log the event to the depositor's profile stream
-    depositor.log_profile_event(event)
-    # Log the event to the FS's stream
-    fs.log_event(event)
-    # Fan out the event to all followers who have access
-    depositor.followers.select { |user| user.can? :read, fs }.each do |follower|
-      follower.log_event(event)
-    end
+# A specific job to log a file new version to a user's activity stream
+class ContentNewVersionEventJob < ContentEventJob
+  def action
+    @action ||= "User #{link_to_profile depositor_id} has added a new version of #{link_to file_set.title.first, Rails.application.routes.url_helpers.curation_concerns_file_set_path(file_set)}"
   end
 end

--- a/app/jobs/content_restored_version_event_job.rb
+++ b/app/jobs/content_restored_version_event_job.rb
@@ -1,18 +1,13 @@
-class ContentRestoredVersionEventJob < EventJob
-  def perform(id, depositor_id, revision_id)
-    fs = FileSet.find(id)
-    action = "User #{link_to_profile depositor_id} has restored a version '#{revision_id}' of #{link_to fs.title.first, Rails.application.routes.url_helpers.curation_concerns_file_set_path(fs)}"
-    timestamp = Time.now.to_i
-    depositor = User.find_by_user_key(depositor_id)
-    # Create the event
-    event = depositor.create_event(action, timestamp)
-    # Log the event to the depositor's profile stream
-    depositor.log_profile_event(event)
-    # Log the event to the FS's stream
-    fs.log_event(event)
-    # Fan out the event to all followers who have access
-    depositor.followers.select { |user| user.can? :read, fs }.each do |follower|
-      follower.log_event(event)
-    end
+# A specific job to log a file restored version to a user's activity stream
+class ContentRestoredVersionEventJob < ContentEventJob
+  attr_accessor :revision_id
+
+  def perform(generic_file_id, depositor_id, revision_id)
+    @revision_id = revision_id
+    super(generic_file_id, depositor_id)
+  end
+
+  def action
+    "User #{link_to_profile depositor_id} has restored a version '#{revision_id}' of #{link_to file_set.title.first, Rails.application.routes.url_helpers.curation_concerns_file_set_path(file_set)}"
   end
 end

--- a/app/jobs/content_update_event_job.rb
+++ b/app/jobs/content_update_event_job.rb
@@ -1,18 +1,6 @@
-class ContentUpdateEventJob < EventJob
-  def perform(id, depositor_id)
-    fs = FileSet.find(id)
-    action = "User #{link_to_profile depositor_id} has updated #{link_to fs.title.first, Rails.application.routes.url_helpers.curation_concerns_file_set_path(fs)}"
-    timestamp = Time.now.to_i
-    depositor = User.find_by_user_key(depositor_id)
-    # Create the event
-    event = depositor.create_event(action, timestamp)
-    # Log the event to the depositor's profile stream
-    depositor.log_profile_event(event)
-    # Log the event to the FS's stream
-    fs.log_event(event)
-    # Fan out the event to all followers who have access
-    depositor.followers.select { |user| user.can? :read, fs }.each do |follower|
-      follower.log_event(event)
-    end
+# A specific job to log a file content update to a user's activity stream
+class ContentUpdateEventJob < ContentEventJob
+  def action
+    "User #{link_to_profile depositor_id} has updated #{link_to file_set.title.first, Rails.application.routes.url_helpers.curation_concerns_file_set_path(file_set)}"
   end
 end

--- a/app/jobs/event_job.rb
+++ b/app/jobs/event_job.rb
@@ -1,3 +1,9 @@
+# A generic job for sending events to a user and their followers.
+#
+# This class does not implement a usable action, so it must be implemented in a child class
+#
+# @attr [String] depositor_id  the user the event is specified for
+#
 class EventJob < ActiveJob::Base
   include Rails.application.routes.url_helpers
   include ActionView::Helpers
@@ -6,4 +12,45 @@ class EventJob < ActiveJob::Base
   include SufiaHelper
 
   queue_as :event
+
+  attr_accessor :depositor_id
+
+  # @param depositor_id the id of the user to create the event for
+  def perform(depositor_id)
+    @depositor_id = depositor_id
+
+    # Log the event to the depositor's profile stream
+    log_user_event
+
+    # Fan out the event to all followers who have access
+    log_to_followers
+  end
+
+  # override to provide your specific action for the event you are logging
+  # @abstract
+  def action
+    raise(NotImplementedError, "#action should be implemented by an child class of EventJob")
+  end
+
+  # create an event with an action and a timestamp for the user
+  def event
+    @event ||= depositor.create_event(action, Time.now.to_i)
+  end
+
+  # the user that will be the subject of the event
+  def depositor
+    @depositor ||= User.find_by_user_key(depositor_id)
+  end
+
+  # log the event to the users event stream
+  def log_user_event
+    depositor.log_event(event)
+  end
+
+  # log the event to the users followers
+  def log_to_followers
+    depositor.followers.each do |follower|
+      follower.log_event(event)
+    end
+  end
 end

--- a/app/jobs/user_edit_profile_event_job.rb
+++ b/app/jobs/user_edit_profile_event_job.rb
@@ -1,15 +1,8 @@
+# A specific job to log a user profile edit to a user's activity stream
 class UserEditProfileEventJob < EventJob
-  def perform(editor_id)
-    action = "User #{link_to_profile editor_id} has edited his or her profile"
-    timestamp = Time.now.to_i
-    editor = User.find_by_user_key(editor_id)
-    # Create the event
-    event = editor.create_event(action, timestamp)
-    # Log the event to the editor's stream
-    editor.log_event(event)
-    # Fan out the event to all followers
-    editor.followers.each do |user|
-      user.log_event(event)
-    end
+  alias_attribute :editor_id, :depositor_id
+
+  def action
+    "User #{link_to_profile editor_id} has edited his or her profile"
   end
 end

--- a/app/jobs/user_follow_event_job.rb
+++ b/app/jobs/user_follow_event_job.rb
@@ -1,16 +1,22 @@
+# A specific job to log a user following another user to a user's activity stream
 class UserFollowEventJob < EventJob
+  attr_accessor :followee_id
+  alias_attribute :follower_id, :depositor_id
+
   def perform(follower_id, followee_id)
-    # Create the event
-    follower = User.find_by_user_key(follower_id)
-    event = follower.create_event("User #{link_to_profile follower_id} is now following #{link_to_profile followee_id}", Time.now.to_i)
-    # Log the event to the follower's stream
-    follower.log_event(event)
+    @followee_id = followee_id
+    super(follower_id)
+  end
+
+  # log the event to the users event stream
+  def log_user_event
+    super
     # Fan out the event to followee
     followee = User.find_by_user_key(followee_id)
     followee.log_event(event)
-    # Fan out the event to all followers
-    follower.followers.each do |user|
-      user.log_event(event)
-    end
+  end
+
+  def action
+    "User #{link_to_profile follower_id} is now following #{link_to_profile followee_id}"
   end
 end

--- a/app/jobs/user_unfollow_event_job.rb
+++ b/app/jobs/user_unfollow_event_job.rb
@@ -1,18 +1,21 @@
+# A specific job to log a user unfollowing another user to a user's activity stream
 class UserUnfollowEventJob < EventJob
+  attr_accessor :unfollowee_id
+  alias_attribute :unfollower_id, :depositor_id
+
   def perform(unfollower_id, unfollowee_id)
-    action = "User #{link_to_profile unfollower_id} has unfollowed #{link_to_profile unfollowee_id}"
-    timestamp = Time.now.to_i
-    unfollower = User.find_by_user_key(unfollower_id)
-    # Create the event
-    event = unfollower.create_event(action, timestamp)
-    # Log the event to the unfollower's stream
-    unfollower.log_event(event)
-    # Fan out the event to unfollowee
+    @unfollowee_id = unfollowee_id
+    super(unfollower_id)
+  end
+
+  # log the event to the users event stream
+  def log_user_event
+    super
     unfollowee = User.find_by_user_key(unfollowee_id)
     unfollowee.log_event(event)
-    # Fan out the event to all followers
-    unfollower.followers.each do |user|
-      user.log_event(event)
-    end
+  end
+
+  def action
+    "User #{link_to_profile unfollower_id} has unfollowed #{link_to_profile unfollowee_id}"
   end
 end


### PR DESCRIPTION
The base class existed, but had little code.  Instead the code was copied from one job to the new one.
In addition there seemed to be two types of events, one with a user, and one with a user and a file, so I created a second base class to allow for the two types.